### PR TITLE
Test 4.1.1-A-1: Collect resource headers from GET, not initial POST

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
@@ -67,7 +67,12 @@ public class LdprvHttpGet extends AbstractVersioningTest {
                                         ps);
 
         //create ldprv
-        final Response response = createVersionedResource(uri, info);
+        final Response creationResponse = createVersionedResource(uri, info);
+
+        //get location of new resource
+        final String resourceUri = getLocation(creationResponse);
+
+        final Response response = doGet(resourceUri);
 
         //confirm presence of timegate link
         confirmPresenceOfTimeGateLink(response);


### PR DESCRIPTION
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/137