### PR TITLE
Implements tests for org.fcrepo.spec.testsuite.authz.WebACLinking

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -22,9 +22,15 @@ import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
 import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_BODY;
 import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_LINK_HEADER;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.PrintStream;
 import java.io.StringReader;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import javax.ws.rs.core.Link;
 
 import io.restassured.RestAssured;
 import io.restassured.config.EncoderConfig;
@@ -42,6 +48,7 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
@@ -354,4 +361,37 @@ public class AbstractTest {
         return CoreMatchers.both(Matchers.greaterThanOrEqualTo(400)).and(Matchers.lessThan(500));
     }
 
+    protected void confirmPresenceOfLinkValue(final String linkValue, final Response response) {
+        final Link link = Link.valueOf(linkValue);
+        final String relType = link.getRel();
+        Assert.assertEquals(getLinksOfRelType(response, link.getRel()).filter(l -> l.equals(link))
+                                                                      .count(),
+                            1,
+                            "Link header with a value of " + linkValue + " must be present but is not!");
+    }
+
+    protected Stream<Link> getLinksOfRelType(final Response response, final String relType) {
+        return getHeaders(response, "Link")
+            // Link header may include multiple, comma-separated link values
+            .flatMap(header -> Arrays.stream(header.getValue().split(",")).map(linkStr -> Link.valueOf(linkStr)))
+            // Each link value may contain multiple "rel" values
+            .filter(link -> link.getRels().stream().anyMatch(rel -> rel.equalsIgnoreCase(relType)));
+    }
+
+    protected Stream<URI> getLinksOfRelTypeAsUris(final Response response, final String relType) {
+        return getLinksOfRelType(response, relType)
+            .map(link -> link.getUri());
+    }
+
+    protected Stream<Header> getHeaders(final Response response, final String headerName) {
+        return response.getHeaders()
+                       .getList(headerName)
+                       .stream();
+    }
+
+    protected void confirmPresenceOfConstrainedByLink(final Response response) {
+        final String contrainedByUri = "http://www.w3.org/ns/ldp#constrainedBy";
+        assertTrue("Response does not contain link of rel type = " + contrainedByUri,
+                   getLinksOfRelType(response, contrainedByUri).count() > 0);
+    }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACLinking.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACLinking.java
@@ -17,6 +17,9 @@
  */
 package org.fcrepo.spec.testsuite.authz;
 
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
 import org.fcrepo.spec.testsuite.AbstractTest;
 import org.fcrepo.spec.testsuite.TestInfo;
 import org.testng.annotations.Parameters;
@@ -27,7 +30,6 @@ import org.testng.annotations.Test;
  * @since 2018-07-16
  */
 public class WebACLinking extends AbstractTest {
-
 
     /**
      * Constructor
@@ -49,9 +51,23 @@ public class WebACLinking extends AbstractTest {
     @Parameters({"param1"})
     public void linkToAclOnCreation(final String uri) {
         final TestInfo info = setupTest("5.4-A", "linkToAclOnCreation",
-                "A client HTTP POST or PUT request to create a new LDPR may include a rel=\"acl\" link in the " +
-                        "Link header referencing an existing LDP-RS to use as the ACL for the new LDPR.",
-                "https://fedora.info/2018/06/25/spec/#link-acl-on-create", ps);
+                                        "A client HTTP POST or PUT request to create a new LDPR may include a " +
+                                        "rel=\"acl\" link in the " +
+                                        "Link header referencing an existing LDP-RS to use as the ACL for the new " +
+                                        "LDPR.",
+                                        "https://fedora.info/2018/06/25/spec/#link-acl-on-create", ps);
+
+        //create a resource to be used for the acl link
+        final Response aclResponse = createBasicContainer(uri, info.getId() + "-acl");
+        final String aclUri = getLocation(aclResponse);
+
+        //PUT the new Resource
+        final String aclLinkValue = "<" + aclUri + ">; rel=\"acl\"";
+        final Response resource = doPut(uri, Headers.headers(new Header("Link", aclLinkValue)), "test body");
+        final String resourceUri = getLocation(resource);
+        final Response getResource = doGet(resourceUri);
+        confirmPresenceOfLinkValue(aclLinkValue, aclResponse);
+
     }
 
     /**
@@ -63,26 +79,29 @@ public class WebACLinking extends AbstractTest {
     @Parameters({"param1"})
     public void conflictIfNotSupportingAclLink(final String uri) {
         final TestInfo info = setupTest("5.4-B", "conflictIfNotSupportingAclLink",
-                "The server must reject the request and respond with a 4xx or 5xx range status code, such as " +
-                        "409 (Conflict) if it isn't able to create the LDPR with the specified LDP-RS as the ACL.",
-                "https://fedora.info/2018/06/25/spec/#link-acl-on-create", ps);
-    }
+                                        "The server must reject the request and respond with a 4xx or 5xx range " +
+                                        "status code, such as " +
+                                        "409 (Conflict) if it isn't able to create the LDPR with the specified LDP-RS" +
+                                        " as the ACL. " +
+                                        "In that response, the restrictions causing the request to fail must be " +
+                                        "described in a " +
+                                        "resource indicated by a rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link " +
+                                        "in the Link " +
+                                        "response header",
+                                        "https://fedora.info/2018/06/25/spec/#link-acl-on-create", ps);
 
-    /**
-     * 5.4-C - Providing constraints document if Linking to client-provided ACL is not supported
-     *
-     * @param uri of base container of Fedora server
-     */
-    @Test(groups = {"MUST"})
-    @Parameters({"param1"})
-    public void conflictIfNotSupportingAclLinkConstraints(final String uri) {
-        final TestInfo info = setupTest("5.4-C", "conflictIfNotSupportingAclLinkConstraints",
-                "The server must reject the request and respond with a 4xx or 5xx range status code, such as " +
-                        "409 (Conflict) if it isn't able to create the LDPR with the specified LDP-RS as the ACL. " +
-                        "In that response, the restrictions causing the request to fail must be described in a " +
-                        "resource indicated by a rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link in the Link " +
-                        "response header",
-                "https://fedora.info/2018/06/25/spec/#link-acl-on-create", ps);
+        //create a resource to be used for the acl link
+        final Response aclResponse = createBasicContainer(uri, info.getId() + "-acl");
+        final String aclUri = getLocation(aclResponse);
+
+        //PUT the new Resource
+        final String aclLinkValue = "<" + aclUri + ">; rel=\"acl\"";
+        final Response resource = doPutUnverified(uri, Headers.headers(new Header("Link", aclLinkValue)), "test body");
+
+        if (resource.getStatusCode() >= 400) {
+            confirmPresenceOfConstrainedByLink(resource);
+        }
+
     }
 
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
@@ -23,7 +23,6 @@ import static org.fcrepo.spec.testsuite.Constants.SLUG;
 
 import java.net.URI;
 import java.util.Arrays;
-import java.util.stream.Stream;
 import javax.ws.rs.core.Link;
 
 import io.restassured.http.Header;
@@ -54,25 +53,6 @@ public class AbstractVersioningTest extends AbstractTest {
         return getLinksOfRelTypeAsUris(response, "timemap").findFirst().get();
     }
 
-    protected Stream<Header> getHeaders(final Response response, final String headerName) {
-        return response.getHeaders()
-                       .getList(headerName)
-                       .stream();
-    }
-
-    protected Stream<Link> getLinksOfRelType(final Response response, final String relType) {
-        return getHeaders(response, "Link")
-                // Link header may include multiple, comma-separated link values
-            .flatMap(header -> Arrays.stream(header.getValue().split(",")).map(linkStr -> Link.valueOf(linkStr)))
-                // Each link value may contain multiple "rel" values
-            .filter(link -> link.getRels().stream().anyMatch(rel -> rel.equalsIgnoreCase(relType)));
-    }
-
-    protected Stream<URI> getLinksOfRelTypeAsUris(final Response response, final String relType) {
-        return getLinksOfRelType(response, relType)
-            .map(link -> link.getUri());
-    }
-
     protected Response createVersionedResource(final String uri, final TestInfo info) {
         final Headers headers = new Headers(
             new Header("Link", ORIGINAL_RESOURCE_LINK_HEADER),
@@ -97,15 +77,6 @@ public class AbstractVersioningTest extends AbstractTest {
                                                    return val.equalsIgnoreCase(headerValue);
                                                }).count() > 0;
 
-    }
-
-    protected void confirmPresenceOfLinkValue(final String linkValue, final Response response) {
-        final Link link = Link.valueOf(linkValue);
-        final String relType = link.getRel();
-        Assert.assertEquals(getLinksOfRelType(response, link.getRel()).filter(l -> l.equals(link))
-                                                                      .count(),
-                            1,
-                            "Link header with a value of " + linkValue + " must be present but is not!");
     }
 
     protected void confirmAbsenceOfLinkValue(final String linkValue, final Response response) {

--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -69,7 +69,9 @@
       <class name="org.fcrepo.spec.testsuite.authz.WebACCrossDomain"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACGeneral"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACLinkHeaders"/>
+      -->
       <class name="org.fcrepo.spec.testsuite.authz.WebACLinking"/>
+      <!--
       <class name="org.fcrepo.spec.testsuite.authz.WebACModes"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACRdfSources"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACRepresentation"/>


### PR DESCRIPTION
Two tests added.  5.4-A is expected to fail since we are not supporting this particular  "MAY" requirement.