### PR TITLE
Implements tests in WebACModes:  5.0-F - 5.0-V

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -60,8 +60,8 @@ public class AbstractTest {
 
     protected PrintStream ps;
 
-    protected final String adminUsername;
-    protected final String adminPassword;
+    private final String adminUsername;
+    private final String adminPassword;
     protected final String username;
     protected final String password;
 
@@ -84,11 +84,11 @@ public class AbstractTest {
     /**
      * Constructor
      *
-     * @param username username
-     * @param password password
+     * @param adminUsername admin username
+     * @param adminPassword admin password
      */
-    public AbstractTest(final String username, final String password) {
-        this(username, password, username, password);
+    public AbstractTest(final String adminUsername, final String adminPassword) {
+        this(adminPassword, adminPassword, null, null);
     }
 
     /**
@@ -305,10 +305,6 @@ public class AbstractTest {
         return createRequest().header(SLUG, slug).contentType(contentType);
     }
 
-    private RequestSpecification createRequestAuthOnly() {
-        return createRequestAuthOnly(true);
-    }
-
     private RequestSpecification createRequestAuthOnly(final boolean admin) {
         if (admin) {
             return createRequestAuthOnly(this.adminUsername, this.adminPassword);
@@ -368,10 +364,6 @@ public class AbstractTest {
         response.then().statusCode(204);
 
         return response;
-    }
-
-    private Response doHeadUnverified(final String uri) {
-       return doHeadUnverified(uri, true);
     }
 
     private Response doHeadUnverified(final String uri, final boolean admin) {

--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -29,7 +29,6 @@ import java.io.StringReader;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.stream.Stream;
-
 import javax.ws.rs.core.Link;
 
 import io.restassured.RestAssured;
@@ -55,14 +54,32 @@ import org.testng.annotations.BeforeMethod;
 /**
  * A crud base class for common crud functions.
  *
- * @author Daniel Berntein
+ * @author dbernstein
  */
 public class AbstractTest {
 
     protected PrintStream ps;
 
+    protected final String adminUsername;
+    protected final String adminPassword;
     protected final String username;
     protected final String password;
+
+    /**
+     * Constructor
+     *
+     * @param adminUsername admin password
+     * @param adminPassword admin username
+     * @param username username
+     * @param password password
+     */
+    public AbstractTest(final String adminUsername, final String adminPassword, final String username,
+                        final String password) {
+        this.adminUsername = adminUsername;
+        this.adminPassword = adminPassword;
+        this.username = username;
+        this.password = password;
+    }
 
     /**
      * Constructor
@@ -71,8 +88,7 @@ public class AbstractTest {
      * @param password password
      */
     public AbstractTest(final String username, final String password) {
-        this.username = username;
-        this.password = password;
+        this(username, password, username, password);
     }
 
     /**
@@ -165,10 +181,15 @@ public class AbstractTest {
     }
 
     protected Response doPostUnverified(final String uri, final Headers headers, final String body) {
-        return createRequest().headers(headers)
-                .body(body)
-                .when()
-                .post(uri);
+        return doPostUnverified(uri,headers, body, true);
+    }
+
+    protected Response doPostUnverified(final String uri, final Headers headers, final String body,
+                                        final boolean admin) {
+        return createRequest(admin).headers(headers)
+                                   .body(body)
+                                   .when()
+                                   .post(uri);
     }
 
     private Response doPostUnverified(final String uri, final String body) {
@@ -216,18 +237,25 @@ public class AbstractTest {
     }
 
     protected Response doPost(final String uri, final Headers headers, final String body) {
-        final Response response = doPostUnverified(uri, headers, body);
+        return doPost(uri, headers, body, true);
+    }
 
+    protected Response doPost(final String uri, final Headers headers, final String body, final boolean admin) {
+        final Response response = doPostUnverified(uri, headers, body, admin);
         response.then().statusCode(201);
-
         return response;
     }
 
     protected Response doPutUnverified(final String uri, final Headers headers, final String body) {
-        return createRequest().headers(headers)
-                .body(body)
-                .when()
-                .put(uri);
+        return doPutUnverified(uri, headers, body, true);
+    }
+
+    protected Response doPutUnverified(final String uri, final Headers headers, final String body,
+                                       final boolean admin) {
+        return createRequest(admin).headers(headers)
+                                   .body(body)
+                                   .when()
+                                   .put(uri);
     }
 
     protected Response doPutUnverified(final String uri, final Headers headers) {
@@ -261,12 +289,16 @@ public class AbstractTest {
         return response;
     }
 
-
     private RequestSpecification createRequest() {
-        return createRequestAuthOnly().config(RestAssured.config().redirect(redirectConfig().followRedirects(false))
-                                      .logConfig(new LogConfig().defaultStream(ps)
-                                                                .enableLoggingOfRequestAndResponseIfValidationFails()))
-                                      .log().all();
+        return createRequest(true);
+    }
+
+    private RequestSpecification createRequest(final boolean admin) {
+        return createRequestAuthOnly(admin)
+            .config(RestAssured.config().redirect(redirectConfig().followRedirects(false))
+                               .logConfig(new LogConfig().defaultStream(ps)
+                                                         .enableLoggingOfRequestAndResponseIfValidationFails()))
+            .log().all();
     }
 
     private RequestSpecification createRequest(final String slug, final String contentType) {
@@ -274,8 +306,20 @@ public class AbstractTest {
     }
 
     private RequestSpecification createRequestAuthOnly() {
+        return createRequestAuthOnly(true);
+    }
+
+    private RequestSpecification createRequestAuthOnly(final boolean admin) {
+        if (admin) {
+            return createRequestAuthOnly(this.adminUsername, this.adminPassword);
+        } else {
+            return createRequestAuthOnly(this.username, this.password);
+        }
+    }
+
+    private RequestSpecification createRequestAuthOnly(final String username, final String password) {
         return RestAssured.given()
-                          .auth().basic(this.username, this.password).urlEncodingEnabled(false);
+                          .auth().basic(username, password).urlEncodingEnabled(false);
     }
 
     protected Response doGet(final String uri, final Header header) {
@@ -286,12 +330,16 @@ public class AbstractTest {
         return response;
     }
 
-    protected Response doGet(final String uri) {
-        final Response response = doGetUnverified(uri);
+    protected Response doGet(final String uri, final boolean admin) {
+        final Response response = doGetUnverified(uri, admin);
 
         response.then().statusCode(200);
 
         return response;
+    }
+
+    protected Response doGet(final String uri) {
+        return doGet(uri, true);
     }
 
     protected Response doGetUnverified(final String uri, final Header header) {
@@ -299,15 +347,23 @@ public class AbstractTest {
     }
 
     protected Response doGetUnverified(final String uri) {
-        return createRequest().when().get(uri);
+        return doGetUnverified(uri,true);
     }
 
-    private Response doDeleteUnverified(final String uri) {
-        return createRequest().when().delete(uri);
+    protected Response doGetUnverified(final String uri, final boolean admin) {
+        return createRequest(admin).when().get(uri);
+    }
+
+    protected Response doDeleteUnverified(final String uri, final boolean admin) {
+        return createRequest(admin).when().delete(uri);
     }
 
     protected Response doDelete(final String uri) {
-        final Response response = doDeleteUnverified(uri);
+        return doDelete(uri, true);
+    }
+
+    protected Response doDelete(final String uri, final boolean admin) {
+        final Response response = doDeleteUnverified(uri, admin);
 
         response.then().statusCode(204);
 
@@ -315,19 +371,31 @@ public class AbstractTest {
     }
 
     private Response doHeadUnverified(final String uri) {
-        return createRequest().when().head(uri);
+       return doHeadUnverified(uri, true);
     }
 
-    protected Response doHead(final String uri) {
-        final Response response = doHeadUnverified(uri);
+    private Response doHeadUnverified(final String uri, final boolean admin) {
+        return createRequest(admin).when().head(uri);
+    }
+
+    protected Response doHead(final String uri, final boolean admin) {
+        final Response response = doHeadUnverified(uri, admin);
 
         response.then().statusCode(200);
 
         return response;
     }
 
+    protected Response doHead(final String uri) {
+        return doHead(uri, true);
+    }
+
     protected Response doPatch(final String uri, final Headers headers, final String body) {
-        final Response response = doPatchUnverified(uri, headers, body);
+        return doPatch(uri, headers, body, true);
+    }
+
+    protected Response doPatch(final String uri, final Headers headers, final String body, final boolean admin) {
+        final Response response = doPatchUnverified(uri, headers, body, admin);
 
         response.then().statusCode(successRange());
 
@@ -335,10 +403,15 @@ public class AbstractTest {
     }
 
     protected Response doPatchUnverified(final String uri, final Headers headers, final String body) {
-        return createRequest().config(
-                RestAssured.config().encoderConfig(
-                        new EncoderConfig().encodeContentTypeAs(APPLICATION_SPARQL_UPDATE, ContentType.TEXT)))
-                .headers(headers).body(body).when().patch(uri);
+        return doPatchUnverified(uri, headers, body, true);
+    }
+
+    protected Response doPatchUnverified(final String uri, final Headers headers, final String body,
+                                         final boolean admin) {
+        return createRequest(admin).config(
+            RestAssured.config().encoderConfig(
+                new EncoderConfig().encodeContentTypeAs(APPLICATION_SPARQL_UPDATE, ContentType.TEXT)))
+                                   .headers(headers).body(body).when().patch(uri);
     }
 
     protected Response doPatchUnverified(final String uri) {

--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -52,12 +52,19 @@ public class App {
         final Option baseurl = new Option("b", "baseurl", true, "base url");
         baseurl.setRequired(true);
         options.addOption(baseurl);
-        final Option user = new Option("u", "user", true, "user login");
-        user.setRequired(false);
+        final Option user = new Option("u", "user", true, "Username of user with basic user role");
+        user.setRequired(true);
         options.addOption(user);
-        final Option password = new Option("p", "password", true, "user's password");
-        password.setRequired(false);
+        final Option password = new Option("p", "password", true, "Password of user with basic user role");
+        password.setRequired(true);
         options.addOption(password);
+        final Option adminUser = new Option("a", "admin-user", true, "Username of user with admin role");
+        adminUser.setRequired(true);
+        options.addOption(adminUser);
+        final Option adminPassword = new Option("s", "admin-password", true, "Password of user with basic admin role");
+        adminPassword.setRequired(true);
+        options.addOption(adminPassword);
+
         final Option testngxml = new Option("x", "testngxml", true, "TestNG XML file");
         testngxml.setRequired(false);
         options.addOption(testngxml);
@@ -82,14 +89,20 @@ public class App {
         final String inputUrl = cmd.getOptionValue("baseurl");
         final String inputUser = cmd.getOptionValue("user") == null ? "" : cmd.getOptionValue("user");
         final String inputPassword = cmd.getOptionValue("password") == null ? "" : cmd.getOptionValue("password");
+        final String inputAdminUser = cmd.getOptionValue("admin-user") == null ? "" : cmd.getOptionValue("admin-user");
+        final String inputAdminPassword =
+            cmd.getOptionValue("admin-password") == null ? "" : cmd.getOptionValue("admin-password");
+
         final String inputXml = cmd.getOptionValue("testngxml");
         final String[] requirements = cmd.getOptionValues("requirements");
 
         //Create the default container
         final Map<String, String> params = new HashMap<>();
         params.put("param1", TestSuiteGlobals.containerTestSuite(inputUrl, inputUser, inputPassword));
-        params.put("param2", inputUser);
-        params.put("param3", inputPassword);
+        params.put("param2", inputAdminUser);
+        params.put("param3", inputAdminPassword);
+        params.put("param4", inputUser);
+        params.put("param5", inputPassword);
 
         InputStream inputStream = null;
         if (inputXml == null) {

--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -61,7 +61,7 @@ public class App {
         final Option adminUser = new Option("a", "admin-user", true, "Username of user with admin role");
         adminUser.setRequired(true);
         options.addOption(adminUser);
-        final Option adminPassword = new Option("s", "admin-password", true, "Password of user with basic admin role");
+        final Option adminPassword = new Option("s", "admin-password", true, "Password of user with admin role");
         adminPassword.setRequired(true);
         options.addOption(adminPassword);
 

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/AbstractAuthzTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/AbstractAuthzTest.java
@@ -54,7 +54,7 @@ public class AbstractAuthzTest extends AbstractTest {
         if (acls.size() > 0) {
             return acls.get(0).getUri().toString();
         } else {
-            return resourceUri + ".acl";
+            throw new RuntimeException("No link of type rel=\"acl\" found on resource: " + resourceUri);
         }
     }
 

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/AbstractAuthzTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/AbstractAuthzTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite.authz;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Link;
+
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
+import org.apache.commons.io.IOUtils;
+import org.fcrepo.spec.testsuite.AbstractTest;
+import org.testng.annotations.Parameters;
+
+/**
+ * @author Daniel Bernstein
+ */
+public class AbstractAuthzTest extends AbstractTest {
+    /**
+     * Constructor
+     *
+     * @param adminUsername admin username
+     * @param adminPassword admin password
+     * @param username      username
+     * @param password      password
+     */
+    @Parameters({"param2", "param3", "param4", "param5"})
+    public AbstractAuthzTest(final String adminUsername, final String adminPassword, final String username,
+                             final String password) {
+        super(adminUsername, adminPassword, username, password);
+    }
+
+    protected String getAclLocation(final String resourceUri) {
+        //get or create the resource
+        final Response resourceResponse = doGet(resourceUri);
+        final List<Link> acls = getLinksOfRelType(resourceResponse, "acl").collect(Collectors.toList());
+        if (acls.size() > 0) {
+            return acls.get(0).getUri().toString();
+        } else {
+            return resourceUri + ".acl";
+        }
+    }
+
+    protected String getAclAsString(final String fileName, final String resourceUri, final String username) {
+        try (InputStream is = getClass().getResourceAsStream("/acls/" + fileName)) {
+            return IOUtils.toString(is, "UTF-8").replace("${resource}", resourceUri).replace("${user}", username);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    protected String createResource(final String baseUri, final String resourceId) {
+        final Response resourceResponse = createBasicContainer(baseUri, resourceId);
+        return getLocation(resourceResponse);
+    }
+
+    protected String createAclForResource(final String resourceUri, final String aclFileName, final String username) {
+        //get acl handle
+        final String aclUri = getAclLocation(resourceUri);
+        //create read acl for user role
+        final Response response = doPutUnverified(aclUri, new Headers(new Header("Content-Type", "text/turtle")),
+                                                  getAclAsString(aclFileName, resourceUri, username));
+        response.then().statusCode(201);
+        return aclUri;
+    }
+
+
+
+}
+

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -63,7 +63,7 @@ public class WebACModes extends AbstractAuthzTest {
 
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-only.ttl", this.username);
         //perform verified head as non-admin
         doHead(resourceUri, false);
     }
@@ -83,7 +83,7 @@ public class WebACModes extends AbstractAuthzTest {
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-only.ttl", this.username);
         //perform GET as non-admin
         doGet(resourceUri, false);
     }
@@ -105,7 +105,7 @@ public class WebACModes extends AbstractAuthzTest {
 
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", "not-" + this.username);
+        createAclForResource(resourceUri, "user-read-only.ttl", "not-" + this.username);
         //perform GET as non-admin
         final Response getResponse = doGetUnverified(resourceUri, false);
         //verify unauthorized
@@ -128,7 +128,7 @@ public class WebACModes extends AbstractAuthzTest {
 
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-write.ttl", this.username);
         //perform PUT  to child resource as non-admin
         final Response putResponse =
             doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
@@ -154,10 +154,9 @@ public class WebACModes extends AbstractAuthzTest {
 
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-write.ttl", this.username);
         //perform POST  to child resource as non-admin
-        doPost(resourceUri, new Headers(new Header("Content-Type", "text/plain"),
-                                        new Header("Slug", "child2")),
+        doPost(resourceUri, new Headers(new Header("Content-Type", "text/plain")),
                "test", false);
     }
 
@@ -176,7 +175,7 @@ public class WebACModes extends AbstractAuthzTest {
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-write.ttl", this.username);
         //perform DELETE  to child resource as non-admin
         doDelete(resourceUri, false);
     }
@@ -202,7 +201,7 @@ public class WebACModes extends AbstractAuthzTest {
 
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-write.ttl", this.username);
         //perform PATCH  to child resource as non-admin
         doPatch(resourceUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body, false);
 
@@ -223,7 +222,7 @@ public class WebACModes extends AbstractAuthzTest {
 
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-only.ttl", this.username);
         //perform PUT  to child resource as non-admin with read only prives
         final Response putResponse =
             doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
@@ -246,10 +245,9 @@ public class WebACModes extends AbstractAuthzTest {
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-only.ttl", this.username);
         //perform POST  to child resource as non-admin
-        final Response postResponse = doPostUnverified(resourceUri, new Headers(
-                                                           new Header("Slug", "child2")),
+        final Response postResponse = doPostUnverified(resourceUri, new Headers(),
                                                        "test", false);
         postResponse.then().statusCode(403);
     }
@@ -268,7 +266,7 @@ public class WebACModes extends AbstractAuthzTest {
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-only.ttl", this.username);
         //perform DELETE  to child resource as non-admin
         final Response deleteResponse = doDeleteUnverified(resourceUri, false);
         deleteResponse.then().statusCode(403);
@@ -294,7 +292,7 @@ public class WebACModes extends AbstractAuthzTest {
 
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-only.ttl", this.username);
         //perform PATCH  to child resource as non-admin
         final Response patchResponse =
             doPatchUnverified(resourceUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body,
@@ -317,9 +315,9 @@ public class WebACModes extends AbstractAuthzTest {
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
         //create a resource
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
         //perform POST  to child resource as non-admin
-        doPost(resourceUri, new Headers(new Header("Slug", "child")),
+        doPost(resourceUri, new Headers(),
                "test", false);
 
     }
@@ -344,7 +342,7 @@ public class WebACModes extends AbstractAuthzTest {
                             + " WHERE { }";
 
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
         //perform PATCH  to child resource as non-admin
         doPatch(resourceUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body, false);
     }
@@ -372,7 +370,7 @@ public class WebACModes extends AbstractAuthzTest {
                             + " WHERE { }";
 
         final String resourceUri = createResource(uri, info.getId());
-        final String aclUri = createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
         //perform PATCH  to child resource as non-admin
         final Response patchResponse =
             doPatchUnverified(resourceUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body,

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -17,29 +17,35 @@
  */
 package org.fcrepo.spec.testsuite.authz;
 
-import org.fcrepo.spec.testsuite.AbstractTest;
+import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
+
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
 import org.fcrepo.spec.testsuite.TestInfo;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 /**
  * @author awoods
+ * @author dbernstein
  * @since 2018-07-14
  */
-public class WebACModes extends AbstractTest {
-
+public class WebACModes extends AbstractAuthzTest {
 
     /**
      * Constructor
      *
-     * @param username username
-     * @param password password
+     * @param adminUsername admin username
+     * @param adminPassword admin password
+     * @param username      username
+     * @param password      password
      */
-    @Parameters({"param2", "param3"})
-    public WebACModes(final String username, final String password) {
-        super(username, password);
+    @Parameters({"param2", "param3", "param4", "param5"})
+    public WebACModes(final String adminUsername, final String adminPassword, final String username,
+                      final String password) {
+        super(adminUsername, adminPassword, username, password);
     }
-
 
     /**
      * 5.0-F -Read access on HEAD
@@ -50,35 +56,60 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void readAllowedHEAD(final String uri) {
         final TestInfo info = setupTest("5.0-F", "readAllowedHEAD",
-                "acl:Read gives access to a class of operations that can be described as \"Read Access\". " +
-                        "In a typical REST API, this includes access to HTTP verbs HEAD.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Read gives access to a class of operations that can be described as " +
+                                        "\"Read Access\". " +
+                                        "In a typical REST API, this includes access to HTTP verbs HEAD.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        //perform verified head as non-admin
+        doHead(resourceUri, false);
     }
 
     /**
      * 5.0-G -Read access on GET
+     *
      * @param uri of base container of Fedora server
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void readAllowedGET(final String uri) {
         final TestInfo info = setupTest("5.0-G", "readAllowedGET",
-                "acl:Read gives access to a class of operations that can be described as \"Read Access\". " +
-                        "In a typical REST API, this includes access to HTTP verbs GET.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Read gives access to a class of operations that can be described as " +
+                                        "\"Read Access\". " +
+                                        "In a typical REST API, this includes access to HTTP verbs GET.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        //perform GET as non-admin
+        doGet(resourceUri, false);
     }
 
     /**
      * 5.0-H -Read access disallowed
+     *
      * @param uri of base container of Fedora server
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void readDisallowed(final String uri) {
         final TestInfo info = setupTest("5.0-H", "readDisallowed",
-                "acl:Read gives access to a class of operations that can be described as \"Read Access\". " +
-                        "In a typical REST API, this includes access to HTTP verbs GET. Its absence must prevent reads",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Read gives access to a class of operations that can be described as " +
+                                        "\"Read Access\". " +
+                                        "In a typical REST API, this includes access to HTTP verbs GET. Its absence " +
+                                        "must prevent reads",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", "not-" + this.username);
+        //perform GET as non-admin
+        final Response getResponse = doGetUnverified(resourceUri, false);
+        //verify unauthorized
+        getResponse.then().statusCode(403);
     }
 
     /**
@@ -90,9 +121,21 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void writeAllowedPUT(final String uri) {
         final TestInfo info = setupTest("5.0-I", "writeAllowedPUT",
-                "acl:Write gives access to a class of operations that can modify the resource. In a REST API " +
-                        "context, this would include PUT.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Write gives access to a class of operations that can modify the resource" +
+                                        ". In a REST API " +
+                                        "context, this would include PUT.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        //perform PUT  to child resource as non-admin
+        final Response putResponse =
+            doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
+                            "test", false);
+        //verify successful
+        putResponse.then().statusCode(201);
+
     }
 
     /**
@@ -104,9 +147,18 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void writeAllowedPOST(final String uri) {
         final TestInfo info = setupTest("5.0-J", "writeAllowedPOST",
-                "acl:Write gives access to a class of operations that can modify the resource. In a REST API " +
-                        "context, this would include POST.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Write gives access to a class of operations that can modify the resource" +
+                                        ". In a REST API " +
+                                        "context, this would include POST.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        //perform POST  to child resource as non-admin
+        doPost(resourceUri, new Headers(new Header("Content-Type", "text/plain"),
+                                        new Header("Slug", "child2")),
+               "test", false);
     }
 
     /**
@@ -118,9 +170,15 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void writeAllowedDELETE(final String uri) {
         final TestInfo info = setupTest("5.0-K", "writeAllowedDELETE",
-                "acl:Write gives access to a class of operations that can modify the resource. In a REST API " +
-                        "context, this would include DELETE",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Write gives access to a class of operations that can modify the resource" +
+                                        ". In a REST API " +
+                                        "context, this would include DELETE",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        //perform DELETE  to child resource as non-admin
+        doDelete(resourceUri, false);
     }
 
     /**
@@ -132,23 +190,116 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void writeAllowedPATCH(final String uri) {
         final TestInfo info = setupTest("5.0-L", "writeAllowedPATCH",
-                "acl:Write gives access to a class of operations that can modify the resource. In a REST API " +
-                        "context, this would include PATCH.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Write gives access to a class of operations that can modify the resource" +
+                                        ". In a REST API " +
+                                        "context, this would include PATCH.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        final String body = "PREFIX dcterms: <http://purl.org/dc/terms/>"
+                            + " INSERT {"
+                            + " <> dcterms:description \"Patch Updated Description\" ."
+                            + "}"
+                            + " WHERE { }";
+
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        //perform PATCH  to child resource as non-admin
+        doPatch(resourceUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body, false);
+
     }
 
     /**
-     * 5.0-M - Write access disallowed
+     * 5.0-M-1 - Write access disallowed on PUT
      *
      * @param uri of base container of Fedora server
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void writeDisallowed(final String uri) {
-        final TestInfo info = setupTest("5.0-M", "writeDisallowed",
-                "acl:Write gives access to a class of operations that can modify the resource. In a REST API " +
-                        "context, this would include PUT, POST, DELETE and PATCH. Its absence must prevent writes",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+    public void writeDisallowedPut(final String uri) {
+        final TestInfo info = setupTest("5.0-M-1", "writeDisallowedPut",
+                                        "acl:Write gives access to PUT a resource. When not present, " +
+                                        "writes should be disallowed.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        //perform PUT  to child resource as non-admin with read only prives
+        final Response putResponse =
+            doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
+                            "test", false);
+        //verify unauthorized
+        putResponse.then().statusCode(403);
+    }
+
+    /**
+     * 5.0-M - Write access disallowed POST
+     *
+     * @param uri of base container of Fedora server
+     */
+    @Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void writeDisallowedPost(final String uri) {
+        final TestInfo info = setupTest("5.0-M-2", "writeDisallowedPost",
+                                        "acl:Write gives access to POST a resource. When not present, " +
+                                        "writes should be disallowed.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        //perform POST  to child resource as non-admin
+        final Response postResponse = doPostUnverified(resourceUri, new Headers(
+                                                           new Header("Slug", "child2")),
+                                                       "test", false);
+        postResponse.then().statusCode(403);
+    }
+
+    /**
+     * 5.0-M - Write access disallowed on DELETE
+     *
+     * @param uri of base container of Fedora server
+     */
+    @Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void writeDisallowedDelete(final String uri) {
+        final TestInfo info = setupTest("5.0-M-3", "writeDisallowedDelete",
+                                        "acl:Write gives access to DELETE a resource. When not present, " +
+                                        "writes should be disallowed.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        //perform DELETE  to child resource as non-admin
+        final Response deleteResponse = doDeleteUnverified(resourceUri, false);
+        deleteResponse.then().statusCode(403);
+    }
+
+    /**
+     * 5.0-M-4 - Write access disallowed on PATCH
+     *
+     * @param uri of base container of Fedora server
+     */
+    @Test(groups = {"MUST"})
+    @Parameters({"param1"})
+    public void writeDisallowedPatch(final String uri) {
+        final TestInfo info = setupTest("5.0-M-4", "writeDisallowedPatch",
+                                        "acl:Write gives access to PATCH a resource. When not present, " +
+                                        "writes should be disallowed.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        final String body = "PREFIX dcterms: <http://purl.org/dc/terms/>"
+                            + " INSERT {"
+                            + " <> dcterms:description \"Patch Updated Description\" ."
+                            + "}"
+                            + " WHERE { }";
+
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        //perform PATCH  to child resource as non-admin
+        final Response patchResponse =
+            doPatchUnverified(resourceUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body,
+                              false);
+        patchResponse.then().statusCode(403);
     }
 
     /**
@@ -160,9 +311,17 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void appendAllowedPOST(final String uri) {
         final TestInfo info = setupTest("5.0-N", "appendAllowedPOST",
-                "acl:Append gives a more limited ability to write to a resource -- Append-Only. " +
-                        "This generally includes the HTTP verb POST.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Append gives a more limited ability to write to a resource -- " +
+                                        "Append-Only. " +
+                                        "This generally includes the HTTP verb POST.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+        //perform POST  to child resource as non-admin
+        doPost(resourceUri, new Headers(new Header("Slug", "child")),
+               "test", false);
+
     }
 
     /**
@@ -174,10 +333,22 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void appendAllowedPATCH(final String uri) {
         final TestInfo info = setupTest("5.0-O", "appendAllowedPATCH",
-                "acl:Append gives a more limited ability to write to a resource -- Append-Only. " +
-                        "This generally includes the INSERT-only portion of SPARQL-based PATCHes.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Append gives a more limited ability to write to a resource -- " +
+                                        "Append-Only. " +
+                                        "This generally includes the INSERT-only portion of SPARQL-based PATCHes.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        final String body = "PREFIX dcterms: <http://purl.org/dc/terms/>"
+                            + " INSERT {"
+                            + " <> dcterms:description \"Patch Updated Description\" ."
+                            + "}"
+                            + " WHERE { }";
+
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+        //perform PATCH  to child resource as non-admin
+        doPatch(resourceUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body, false);
     }
+
     /**
      * 5.0-P - Append access disallowed
      *
@@ -187,11 +358,27 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void appendDisallowed(final String uri) {
         final TestInfo info = setupTest("5.0-P", "appendDisallowed",
-                "acl:Append gives a more limited ability to write to a resource -- Append-Only. " +
-                        "This generally includes the HTTP verb POST, although some implementations may also extend " +
-                        "this mode to cover non-overwriting PUTs, as well as the INSERT-only portion of " +
-                        "SPARQL-based PATCHes. Its absence must prevent append updates.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Append gives a more limited ability to write to a resource -- " +
+                                        "Append-Only. " +
+                                        "This generally includes the HTTP verb POST, although some implementations " +
+                                        "may also extend " +
+                                        "this mode to cover non-overwriting PUTs, as well as the INSERT-only portion " +
+                                        "of SPARQL-based PATCHes. Its absence must prevent append updates.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        final String body = "PREFIX acl: <http://www.w3.org/ns/auth/acl#>"
+                            + " DELETE {"
+                            + " <#restricted> acl:mode acl:Read ."
+                            + "}"
+                            + " WHERE { }";
+
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+        //perform PATCH  to child resource as non-admin
+        final Response patchResponse =
+            doPatchUnverified(resourceUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body,
+                              false);
+        //verify unauthorized
+        patchResponse.then().statusCode(403);
     }
 
     /**
@@ -203,9 +390,15 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void controlAllowedGET(final String uri) {
         final TestInfo info = setupTest("5.0-Q", "controlAllowedGET",
-                "acl:Control is a special-case access mode that gives an agent the ability to view the ACL of a " +
-                        "resource.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Control is a special-case access mode that gives an agent the ability to" +
+                                        " view the ACL of a " +
+                                        "resource.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-control.ttl", this.username);
+        //perform verified get as non-admin
+        doGet(aclUri, false);
+
     }
 
     /**
@@ -217,9 +410,21 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void controlAllowedPATCH(final String uri) {
         final TestInfo info = setupTest("5.0-R", "controlAllowedPATCH",
-                "acl:Control is a special-case access mode that gives an agent the ability to modify the ACL of a " +
-                        "resource.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Control is a special-case access mode that gives an agent the ability to" +
+                                        " modify the ACL of a " +
+                                        "resource.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        final String body = "PREFIX acl: <http://www.w3.org/ns/auth/acl#>"
+                            + " INSERT {"
+                            + " <#restricted> acl:mode acl:Read ."
+                            + "}"
+                            + " WHERE { }";
+
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-control.ttl", this.username);
+        //perform PATCH  to resource's acl as non-admin
+        doPatch(aclUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body, false);
     }
 
     /**
@@ -231,9 +436,26 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void controlAllowedPUT(final String uri) {
         final TestInfo info = setupTest("5.0-S", "controlAllowedPUT",
-                "acl:Control is a special-case access mode that gives an agent the ability to modify the ACL of a " +
-                        "resource.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Control is a special-case access mode that gives an agent the ability to" +
+                                        " modify the ACL of a " +
+                                        "resource.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        final String resourceUri = createResource(uri, info.getId());
+        createAclForResource(resourceUri, "user-control.ttl", this.username);
+        //perform PUT  to child resource as non-admin
+        final Response putResponse =
+            doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
+                            "test", false);
+        //verify successful
+        putResponse.then().statusCode(201);
+
+        //get acl location of child
+        final String childResourceUri = getLocation(putResponse);
+        final String childAclUri = getAclLocation(childResourceUri);
+
+        doPut(childAclUri, new Headers(new Header("Content-Type", "text/turtle")),
+              getAclAsString("user-read-only.ttl", childResourceUri, this.username));
     }
 
     /**
@@ -245,9 +467,16 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void controlDisallowedGET(final String uri) {
         final TestInfo info = setupTest("5.0-T", "controlDisallowedGET",
-                "acl:Control is a special-case access mode that gives an agent the ability to view and modify the " +
-                        "ACL of a resource. Its absence must prevent viewing the ACL.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Control is a special-case access mode that gives an agent the ability to" +
+                                        " view and modify the " +
+                                        "ACL of a resource. Its absence must prevent viewing the ACL.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        //perform a GET on the acl using the non-admin user
+        final Response getResponse = doGetUnverified(aclUri, false);
+        getResponse.then().statusCode(403);
     }
 
     /**
@@ -259,9 +488,24 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void controlDisallowedPATCH(final String uri) {
         final TestInfo info = setupTest("5.0-U", "controlDisallowedPATCH",
-                "acl:Control is a special-case access mode that gives an agent the ability to view and modify the " +
-                        "ACL of a resource. Its absence must prevent updating the ACL.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Control is a special-case access mode that gives an agent the ability to" +
+                                        " view and modify the " +
+                                        "ACL of a resource. Its absence must prevent updating the ACL.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        final String body = "PREFIX acl: <http://www.w3.org/ns/auth/acl#>"
+                            + " INSERT {"
+                            + " <#restricted> acl:mode acl:Read ."
+                            + "}"
+                            + " WHERE { }";
+        //create a resource
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-only.ttl", this.username);
+        //perform PATCH  to resource's acl as non-admin
+        final Response patchResponse =
+            doPatchUnverified(aclUri, new Headers(new Header("Content-Type", APPLICATION_SPARQL_UPDATE)), body, false);
+        //verify unauthorized
+        patchResponse.then().statusCode(403);
     }
 
     /**
@@ -273,9 +517,28 @@ public class WebACModes extends AbstractTest {
     @Parameters({"param1"})
     public void controlDisallowedPUT(final String uri) {
         final TestInfo info = setupTest("5.0-U", "controlDisallowedPUT",
-                "acl:Control is a special-case access mode that gives an agent the ability to view and modify the " +
-                        "ACL of a resource. Its absence must prevent updating the ACL.",
-                "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+                                        "acl:Control is a special-case access mode that gives an agent the ability to" +
+                                        " view and modify the " +
+                                        "ACL of a resource. Its absence must prevent updating the ACL.",
+                                        "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
+
+        final String resourceUri = createResource(uri, info.getId());
+        final String aclUri = createAclForResource(resourceUri, "user-read-write.ttl", this.username);
+        //perform PUT  to child resource as non-admin
+        final Response putResponse =
+            doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
+                            "test", false);
+        //verify successful
+        putResponse.then().statusCode(201);
+
+        //create child resource acl
+        final String childResourceUri = getLocation(putResponse);
+        final String childAclUri = getAclLocation(childResourceUri);
+        final Response childAclResponse =
+            doPutUnverified(childAclUri, new Headers(new Header("Content-Type", "text/turtle")),
+                            getAclAsString("user-read-write.ttl", childResourceUri, this.username));
+
+        childAclResponse.then().statusCode(403);
     }
 
 }

--- a/src/main/resources/acls/user-control.ttl
+++ b/src/main/resources/acls/user-control.ttl
@@ -1,0 +1,8 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#restricted> a acl:Authorization ;
+              acl:agent "${user}" ;
+              acl:mode acl:Control;
+              acl:default <${resource}> ;
+              acl:accessTo <${resource}> .

--- a/src/main/resources/acls/user-read-append.ttl
+++ b/src/main/resources/acls/user-read-append.ttl
@@ -1,0 +1,9 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#restricted> a acl:Authorization ;
+              acl:agent "${user}" ;
+              acl:mode acl:Read;
+              acl:mode acl:Append;
+              acl:default <${resource}> ;
+              acl:accessTo <${resource}> .

--- a/src/main/resources/acls/user-read-only.ttl
+++ b/src/main/resources/acls/user-read-only.ttl
@@ -1,0 +1,8 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#restricted> a acl:Authorization ;
+              acl:agent "${user}" ;
+              acl:mode acl:Read;
+              acl:default <${resource}> ;
+              acl:accessTo <${resource}> .

--- a/src/main/resources/acls/user-read-write.ttl
+++ b/src/main/resources/acls/user-read-write.ttl
@@ -1,0 +1,9 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#restricted> a acl:Authorization ;
+              acl:agent "${user}" ;
+              acl:mode acl:Read;
+              acl:mode acl:Write;
+              acl:default <${resource}> ;
+              acl:accessTo <${resource}> .

--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -65,13 +65,13 @@
       <class name="org.fcrepo.spec.testsuite.versioning.LdpcvHttpDelete"/>
       <class name="org.fcrepo.spec.testsuite.versioning.LdpcvHttpOptions"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACLinking"/>
+      <class name="org.fcrepo.spec.testsuite.authz.WebACModes"/>
 
       <!-- Below not yet implemented -->
       <!--
       <class name="org.fcrepo.spec.testsuite.authz.WebACCrossDomain"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACGeneral"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACLinkHeaders"/>
-      <class name="org.fcrepo.spec.testsuite.authz.WebACModes"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACRdfSources"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACRepresentation"/>
       -->


### PR DESCRIPTION
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/154
Note1:  Three of the new tests are failing, but should succeed once https://github.com/fcrepo4/fcrepo4/pull/1395 is merged in.
Note2:  with this PR, I've added in two new required parameters to allow for admin username and password.  So -u and -p now refer to "user role" credentials (ie testuser/testpass) and -a and -s are for the admin role (fedoraAdmin/fedoraAdmin).
 -a,--admin-user <arg>       Username of user with admin role
 -s,--admin-password <arg>   Password of user with basic admin role
 -u,--user <arg>             Username of user with basic user role
 -p,--password <arg>         Password of user with basic user role
