### PR TITLE
155 - Adds tests for External Binary Content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <project.copyrightYear>2017</project.copyrightYear>
     <license.plugin.version>2.11</license.plugin.version>
     <javax.xml.version>1.4.5</javax.xml.version>
+    <wiremock.version>2.18.0</wiremock.version>
     <app.main.class>org.fcrepo.spec.testsuite.App</app.main.class>
   </properties>
 
@@ -251,6 +252,11 @@
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
       <version>2.24</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>${wiremock.version}</version>
     </dependency>
 
 

--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -503,9 +503,6 @@ public class AbstractTest {
 
     protected String joinLocation(final String uri, final String... subpaths) {
         final StringBuilder builder = new StringBuilder(uri);
-        if (!uri.endsWith("/")) {
-            builder.append('/');
-        }
         builder.append(String.join("/", subpaths));
         return builder.toString();
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -199,7 +199,7 @@ public class AbstractTest {
                 .post(uri);
     }
 
-    private Response doPostUnverified(final String uri, final Headers headers) {
+    protected Response doPostUnverified(final String uri, final Headers headers) {
         return createRequest().headers(headers)
                 .when()
                 .post(uri);
@@ -267,6 +267,14 @@ public class AbstractTest {
     protected Response doPutUnverified(final String uri) {
         return createRequest().when()
                               .put(uri);
+    }
+
+    protected Response doPut(final String uri, final Headers headers) {
+        final Response response = doPutUnverified(uri, headers);
+
+        response.then().statusCode(204);
+
+        return response;
     }
 
     protected Response doPut(final String uri, final Headers headers, final String body) {
@@ -366,7 +374,7 @@ public class AbstractTest {
         return response;
     }
 
-    private Response doHeadUnverified(final String uri, final boolean admin) {
+    protected Response doHeadUnverified(final String uri, final boolean admin) {
         return createRequest(admin).when().head(uri);
     }
 

--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -500,4 +500,13 @@ public class AbstractTest {
         assertTrue("Response does not contain link of rel type = " + contrainedByUri,
                    getLinksOfRelType(response, contrainedByUri).count() > 0);
     }
+
+    protected String joinLocation(final String uri, final String... subpaths) {
+        final StringBuilder builder = new StringBuilder(uri);
+        if (!uri.endsWith("/")) {
+            builder.append('/');
+        }
+        builder.append(String.join("/", subpaths));
+        return builder.toString();
+    }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/Constants.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/Constants.java
@@ -49,6 +49,8 @@ public class Constants {
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
     public static final String SLUG = "slug";
     public static final String DIGEST = "Digest";
+
+    public static final String LINK = "Link";
     public static final String APPLICATION_SPARQL_UPDATE = "application/sparql-update";
 
     public static final String MEMENTO_LINK_HEADER = "<http://mementoweb.org/ns#Memento>; rel=\"type\"";
@@ -59,6 +61,7 @@ public class Constants {
     public static final String TIME_MAP_LINK_HEADER = "<http://mementoweb.org/ns#TimeMap>; " +
                                                        "rel=\"type\"";
 
+    public static final String EXTERNAL_CONTENT_LINK_REL = "http://fedora.info/definitions/fcrepo#ExternalContent";
 
     private Constants() {
 

--- a/src/main/java/org/fcrepo/spec/testsuite/Constants.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/Constants.java
@@ -21,6 +21,9 @@ package org.fcrepo.spec.testsuite;
  * @author Daniel Bernstein
  */
 public class Constants {
+
+    public static final String NON_RDF_SOURCE_INTERACTION_MODEL = "http://www.w3.org/ns/ldp#NonRDFSource";
+
     public static final String NON_RDF_SOURCE_LINK_HEADER = "<http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\"";
     public static final String CONTAINER_LINK_HEADER = "<http://www.w3.org/ns/ldp#Container>; rel=\"type\"";
     public static final String BASIC_CONTAINER_LINK_HEADER = "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"";

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -132,7 +132,7 @@ public abstract class TestSuiteGlobals {
                                                                        TestSuiteGlobals.outputName + "-execution.log"),
                                                               true);
             return new PrintStream(fos);
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             throw new RuntimeException(ex);
         }
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -132,7 +132,7 @@ public abstract class TestSuiteGlobals {
                                                                        TestSuiteGlobals.outputName + "-execution.log"),
                                                               true);
             return new PrintStream(fos);
-        } catch (final Exception ex) {
+        } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -57,20 +57,20 @@ public abstract class TestSuiteGlobals {
      */
     public static String containerTestSuite(final String baseurl, final String user, final String pass) {
         final String name = outputName + "container" + today();
-        String containerUrl = baseurl + "/" + name;
+        final String base = baseurl.endsWith("/") ? baseurl : baseurl + '/';
+        String containerUrl = base + name + "/";
         containerUrl = containerUrl.replaceAll("(?<!http:)//", "/");
         final Response res = RestAssured.given()
                                         .auth().basic(user, pass)
                                         .contentType("text/turtle")
                                         .header("Link", BASIC_CONTAINER_LINK_HEADER)
                                         .header(SLUG, name)
-                                        .body(BASIC_CONTAINER_LINK_HEADER)
                                         .when()
-                                        .post(baseurl);
+                                        .post(base);
         if (res.getStatusCode() == 201) {
             return containerUrl;
         } else {
-            return baseurl;
+            return base;
         }
     }
 
@@ -132,7 +132,7 @@ public abstract class TestSuiteGlobals {
                                                                        TestSuiteGlobals.outputName + "-execution.log"),
                                                               true);
             return new PrintStream(fos);
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             throw new RuntimeException(ex);
         }
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
@@ -22,6 +22,7 @@ import static org.fcrepo.spec.testsuite.Constants.DIGEST;
 import static org.fcrepo.spec.testsuite.Constants.EXTERNAL_CONTENT_LINK_REL;
 import static org.fcrepo.spec.testsuite.Constants.LINK;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
+import static org.fcrepo.spec.testsuite.Constants.NON_RDF_SOURCE_INTERACTION_MODEL;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -53,7 +54,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.testng.Assert.assertTrue;
-
+import static org.testng.AssertJUnit.assertTrue;
 import static java.util.Collections.emptyList;
 
 /**
@@ -87,7 +88,7 @@ public class ExternalBinaryContent extends AbstractTest {
         wireMockServer = new WireMockServer(options().dynamicPort());
         wireMockServer.start();
         externalUri = mockHttpResource("file.txt", "text/plain", "binary content");
-        externalUriWithNoType = mockHttpResourceNoType("notype2", "other content");
+        externalUriWithNoType = mockHttpResourceNoType("notype", "other content");
 
         final File tempFile = File.createTempFile("ext", null);
         tempFile.deleteOnExit();
@@ -124,7 +125,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-A-1b PostCreate Copy
+     * 3.9-A-1b PostCreate Copy File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -165,7 +166,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-A-2b PostCreate Redirect
+     * 3.9-A-2b PostCreate Redirect File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -205,7 +206,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-A-3b PostCreate Proxy
+     * 3.9-A-3b PostCreate Proxy File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -246,7 +247,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-B-1b PutCreate Copy
+     * 3.9-B-1b PutCreate Copy File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -288,7 +289,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-B-2b PutCreate Redirect
+     * 3.9-B-2b PutCreate Redirect File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -330,7 +331,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-B-3b PutCreate Proxy
+     * 3.9-B-3b PutCreate Proxy File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -364,11 +365,7 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
-        final Headers headers = new Headers(
-                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
-                new Header(SLUG, info.getId()));
-        final Response resource = doPost(uri, headers, "TestString.");
-        final String locationHeader = getLocation(resource);
+        final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "copy")));
@@ -376,7 +373,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-C-1b PutUpdate Copy
+     * 3.9-C-1b PutUpdate Copy File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -389,11 +386,7 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
-        final Headers headers = new Headers(
-                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
-                new Header(SLUG, info.getId()));
-        final Response resource = doPost(uri, headers, "TestString.");
-        final String locationHeader = getLocation(resource);
+        final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "copy")));
@@ -414,11 +407,7 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
-        final Headers headers = new Headers(
-                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
-                new Header(SLUG, info.getId()));
-        final Response resource = doPost(uri, headers, "TestString.");
-        final String locationHeader = getLocation(resource);
+        final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "redirect")));
@@ -426,7 +415,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-C-2b PutUpdate Redirect
+     * 3.9-C-2b PutUpdate Redirect File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -439,11 +428,7 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
-        final Headers headers = new Headers(
-                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
-                new Header(SLUG, info.getId()));
-        final Response resource = doPost(uri, headers, "TestString.");
-        final String locationHeader = getLocation(resource);
+        final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "redirect")));
@@ -464,11 +449,7 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
-        final Headers headers = new Headers(
-                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
-                new Header(SLUG, info.getId()));
-        final Response resource = doPost(uri, headers, "TestString.");
-        final String locationHeader = getLocation(resource);
+        final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "proxy")));
@@ -476,7 +457,7 @@ public class ExternalBinaryContent extends AbstractTest {
     }
 
     /**
-     * 3.9-C-3b PutUpdate Proxy
+     * 3.9-C-3b PutUpdate Proxy File URI
      *
      * @param uri of base container of Fedora server
      */
@@ -489,11 +470,7 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
-        final Headers headers = new Headers(
-                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
-                new Header(SLUG, info.getId()));
-        final Response resource = doPost(uri, headers, "TestString.");
-        final String locationHeader = getLocation(resource);
+        final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "proxy")));
@@ -742,6 +719,7 @@ public class ExternalBinaryContent extends AbstractTest {
                 new Header(SLUG, info.getId()));
         final String location = getLocation(doPost(uri, headers));
 
+
         // Type attribute supersedes Content-Type from external server
         doHead(location).then()
                 .header("Content-Type", "text/special");
@@ -784,6 +762,12 @@ public class ExternalBinaryContent extends AbstractTest {
                         "the request entity must reject request if it cannot guarantee all of the response headers " +
                         "required by the LDP-NR interaction model in this specification.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final String location = createExternalBinary(uri, info.getId(), "proxy", null);
+
+        final Response resp = doGet(location);
+        assertTrue("Response does not contain link of rel type = describedby",
+                getLinksOfRelType(resp, "describedby").count() > 0);
     }
 
     /**
@@ -799,6 +783,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "the request entity must reject request if it cannot guarantee all of the response headers " +
                         "required by the LDP-NR interaction model in this specification.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final String location = createExternalBinary(uri, info.getId(), "proxy", "text/plain");
+
+        doGet(location).then().header("Content-Type", "text/plain");
     }
 
     /**
@@ -814,6 +802,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "the request entity must reject request if it cannot guarantee all of the response headers " +
                         "required by the LDP-NR interaction model in this specification.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final String location = createExternalBinary(uri, info.getId(), "proxy", "text/plain");
+
+        doGet(location).then().header("Content-Length", is(notNullValue()));
     }
 
     /**
@@ -829,6 +821,13 @@ public class ExternalBinaryContent extends AbstractTest {
                         "the request entity must reject request if it cannot guarantee all of the response headers " +
                         "required by the LDP-NR interaction model in this specification.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final String location = createExternalBinary(uri, info.getId(), "proxy", "text/plain");
+
+        final Response resp = doGet(location);
+        assertTrue(getLinksOfRelTypeAsUris(resp, "type")
+                .anyMatch(p -> p.toString().equals(NON_RDF_SOURCE_INTERACTION_MODEL)),
+                "Interaction model link header of rel=type is required");
     }
 
     /**
@@ -861,10 +860,7 @@ public class ExternalBinaryContent extends AbstractTest {
                         "\"Want-Digest\" header.",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
 
-        final Headers headers = new Headers(
-                new Header(LINK, externalContentHeader(externalUri, "redirect")),
-                new Header(SLUG, info.getId()));
-        final String location = getLocation(doPost(uri, headers));
+        final String location = createExternalBinary(uri, info.getId(), "redirect", null);
 
         final String checksum = "md5;q=0.3,sha;q=1";
         final Response wantDigestResponse = doGetUnverified(location, new Header("Want-Digest", checksum));
@@ -887,10 +883,7 @@ public class ExternalBinaryContent extends AbstractTest {
                         "\"Want-Digest\" header.",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
 
-        final Headers headers = new Headers(
-                new Header(LINK, externalContentHeader(externalUri, "proxy")),
-                new Header(SLUG, info.getId()));
-        final String location = getLocation(doPost(uri, headers));
+        final String location = createExternalBinary(uri, info.getId(), "proxy", null);
 
         final String checksum = "md5;q=0.3,sha;q=1";
         final Response wantDigestResponse = doGet(location, new Header("Want-Digest", checksum));
@@ -940,7 +933,7 @@ public class ExternalBinaryContent extends AbstractTest {
                 new Header(SLUG, info.getId()));
         final String location = getLocation(doPostUnverified(uri, headers));
 
-        doHeadUnverified(location).then()
+        doHeadUnverified(location, true).then()
                 .statusCode(anyOf(is(302), is(307)));
     }
 
@@ -1000,5 +993,21 @@ public class ExternalBinaryContent extends AbstractTest {
             link += "; type=\"" + type + "\"";
         }
         return link;
+    }
+
+    private String createExternalBinary(final String uri, final String id, final String handling,
+            final String contentType) {
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, handling, contentType)),
+                new Header(SLUG, id));
+        return getLocation(doPost(uri, headers));
+    }
+
+    private String createNonRdfSource(final String uri, final String id) {
+        final Headers headers = new Headers(
+                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
+                new Header(SLUG, id));
+        final Response resource = doPost(uri, headers, "TestString.");
+        return getLocation(resource);
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
@@ -899,7 +899,7 @@ public class ExternalBinaryContent extends AbstractTest {
         if (header == null) {
             return emptyList();
         }
-        return Arrays.asList(header.split("\\s+,\\s+"));
+        return Arrays.asList(header.split("\\s*,\\s*"));
     }
 
     private String mockHttpResource(final String filename, final String type, final String content) {

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
@@ -17,16 +17,59 @@
  */
 package org.fcrepo.spec.testsuite.crud;
 
+import static org.fcrepo.spec.testsuite.Constants.CONTENT_DISPOSITION;
+import static org.fcrepo.spec.testsuite.Constants.DIGEST;
+import static org.fcrepo.spec.testsuite.Constants.EXTERNAL_CONTENT_LINK_REL;
+import static org.fcrepo.spec.testsuite.Constants.LINK;
+import static org.fcrepo.spec.testsuite.Constants.SLUG;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.fcrepo.spec.testsuite.AbstractTest;
 import org.fcrepo.spec.testsuite.TestInfo;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.testng.Assert.assertTrue;
+
+import static java.util.Collections.emptyList;
 
 /**
  * @author awoods
  * @since 2018-06-28
  */
 public class ExternalBinaryContent extends AbstractTest {
+
+    private final List<String> HANDLINGS = Arrays.asList("copy", "redirect", "proxy");
+
+    private WireMockServer wireMockServer;
+    private String externalUri;
+
+    private String externalUriWithNoType;
+
+    private Boolean extContentSupported;
 
     /**
      * Authentication
@@ -37,6 +80,19 @@ public class ExternalBinaryContent extends AbstractTest {
     @Parameters({"param2", "param3"})
     public ExternalBinaryContent(final String username, final String password) {
         super(username, password);
+
+        wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer.start();
+        externalUri = mockHttpResource("file.txt", "text/plain", "binary content");
+        externalUriWithNoType = mockHttpResourceNoType("notype2", "other content");
+    }
+
+    /**
+     * Stop the mock server
+     */
+    @AfterClass
+    public void stopServer() {
+        wireMockServer.stop();
     }
 
     /**
@@ -52,6 +108,12 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "copy")),
+                new Header(SLUG, info.getId()));
+
+        doPost(uri, headers);
     }
 
     /**
@@ -67,6 +129,11 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "redirect")),
+                new Header(SLUG, info.getId()));
+        doPost(uri, headers);
     }
 
     /**
@@ -82,6 +149,11 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "proxy")),
+                new Header(SLUG, info.getId()));
+        doPost(uri, headers);
     }
 
     /**
@@ -97,6 +169,11 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final String location = uri + info.getId();
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "copy")));
+        doPut(location, headers);
     }
 
     /**
@@ -112,6 +189,11 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final String location = uri + info.getId();
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "redirect")));
+        doPut(location, headers);
     }
 
     /**
@@ -127,6 +209,11 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final String location = uri + info.getId();
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "proxy")));
+        doPut(location, headers);
     }
 
     /**
@@ -142,6 +229,16 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
+                new Header(SLUG, info.getId()));
+        final Response resource = doPost(uri, headers, "TestString.");
+        final String locationHeader = getLocation(resource);
+
+        final Headers headers2 = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "copy")));
+        doPut(locationHeader, headers2);
     }
 
     /**
@@ -157,6 +254,16 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
+                new Header(SLUG, info.getId()));
+        final Response resource = doPost(uri, headers, "TestString.");
+        final String locationHeader = getLocation(resource);
+
+        final Headers headers2 = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "redirect")));
+        doPut(locationHeader, headers2);
     }
 
     /**
@@ -172,6 +279,16 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
+                new Header(SLUG, info.getId()));
+        final Response resource = doPost(uri, headers, "TestString.");
+        final String locationHeader = getLocation(resource);
+
+        final Headers headers2 = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "proxy")));
+        doPut(locationHeader, headers2);
     }
 
     /**
@@ -186,6 +303,17 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers that do not support the creation of LDP-NRs with content external must reject " +
                         "with a 4xx range status code",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (externalContentSupported(uri)) {
+            return;
+        }
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "proxy")),
+                new Header(SLUG, info.getId()));
+        doPostUnverified(uri, headers)
+                .then()
+                .statusCode(clientErrorRange());
     }
 
     /**
@@ -201,6 +329,18 @@ public class ExternalBinaryContent extends AbstractTest {
                         "this restriction in a resource indicated by a " +
                         "rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link in the Link response header.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (externalContentSupported(uri)) {
+            return;
+        }
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "proxy")),
+                new Header(SLUG, info.getId()));
+
+        doPostUnverified(uri, headers)
+                .then()
+                .header("Link", containsString("constrainedBy"));
     }
 
     /**
@@ -216,6 +356,27 @@ public class ExternalBinaryContent extends AbstractTest {
                         "process the request. At least one of the following handling attributes must be supported: " +
                         "copy, redirect, and/or proxy.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final List<String> acceptedHandlingTypes = getAcceptedHandlingTypes(uri);
+
+        final List<String> acceptedAndExpected = acceptedHandlingTypes.stream()
+                .filter(HANDLINGS::contains)
+                .collect(Collectors.toList());
+
+        assertThat("Accept-External-Content-Handling header contains at least one expected handling",
+                acceptedAndExpected.size(), greaterThanOrEqualTo(1));
+
+        // Test that at least one of the handlings specified by the serve is supported
+        for (final String handling : acceptedAndExpected) {
+            final Headers headers = new Headers(
+                    new Header(LINK, externalContentHeader(externalUri, handling)),
+                    new Header(SLUG, info.getId()));
+
+            final Response resp = doPostUnverified(uri, headers);
+            if (resp.statusCode() == 201) {
+                return;
+            }
+        }
     }
 
     /**
@@ -230,6 +391,14 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers must reject with a 4xx range status code requests for which the handling attribute " +
                         "is not present or cannot be respected.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, null)),
+                new Header(SLUG, info.getId()));
+
+        doPostUnverified(uri, headers)
+                .then()
+                .statusCode(clientErrorRange());
     }
 
     /**
@@ -245,6 +414,14 @@ public class ExternalBinaryContent extends AbstractTest {
                         "to fail must be described in a resource indicated by a " +
                         "rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link in the Link response header.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "unsupported")),
+                new Header(SLUG, info.getId()));
+
+        doPostUnverified(uri, headers)
+                .then()
+                .statusCode(clientErrorRange());
     }
 
     /**
@@ -259,6 +436,15 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUriWithNoType, "proxy", "text/special")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPost(uri, headers));
+
+        doHead(location)
+                .then()
+                .header("Content-Type", "text/special");
     }
 
     /**
@@ -275,6 +461,14 @@ public class ExternalBinaryContent extends AbstractTest {
                         "accessing the external content via the specified scheme (e.g. the Content-Type header for " +
                         "external content accessed via http).",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "proxy")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPost(uri, headers));
+
+        doHead(location).then()
+                .header("Content-Type", "text/plain");
     }
 
     /**
@@ -289,6 +483,15 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided. Servers may use a default media type.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUriWithNoType, "proxy")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPost(uri, headers));
+
+        // Verify that any content type is provided, unspecified by the client or the content
+        doHead(location).then()
+                .assertThat().header("Content-Type", not(isEmptyString()));
     }
 
     /**
@@ -304,6 +507,12 @@ public class ExternalBinaryContent extends AbstractTest {
                         "type of the external content, if provided. Servers may reject the request with a 4xx range " +
                         "status code.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUriWithNoType, "proxy")),
+                new Header(SLUG, info.getId()));
+        doPostUnverified(uri, headers).then()
+                .statusCode(clientErrorRange());
     }
 
     /**
@@ -319,6 +528,15 @@ public class ExternalBinaryContent extends AbstractTest {
                         "type of the external content, if provided. Any Content-Type header in the request should be " +
                         "ignored.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "proxy", "text/special")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPost(uri, headers));
+
+        // Type attribute supersedes Content-Type from external server
+        doHead(location).then()
+                .header("Content-Type", "text/special");
     }
 
     /**
@@ -326,14 +544,23 @@ public class ExternalBinaryContent extends AbstractTest {
      *
      * @param uri of base container of Fedora server
      */
-    @Test(groups = {"SHOULD"})
-    @Parameters({"param1"})
+    @Test(groups = { "SHOULD" })
+    @Parameters({ "param1" })
     public void binaryContentContentTypeAndNoType(final String uri) {
         final TestInfo info = setupTest("3.9-F-6", "binaryContentContentTypeAndNoType",
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided. Any Content-Type header in the request should be " +
                         "ignored.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        // Providing external content which does not return Content-Type
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUriWithNoType, "proxy", "text/special")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPost(uri, headers));
+
+        doHead(location).then()
+                .header("Content-Type", "text/special");
     }
 
     /**
@@ -408,6 +635,9 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers supporting external content MUST include \"Accept-External-Content-Handling\" " +
                         "header in response to \"OPTIONS\" request.",
                 "https://fedora.info/2018/06/25/spec/#external-content-options", ps);
+
+        doOptions(uri).then()
+                .assertThat().header("Accept-External-Content-Handling", is(notNullValue()));
     }
 
     /**
@@ -422,6 +652,18 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers supporting \"redirect\" external content types MUST correctly respond to the " +
                         "\"Want-Digest\" header.",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "redirect")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPost(uri, headers));
+
+        final String checksum = "md5;q=0.3,sha;q=1";
+        final Response wantDigestResponse = doGet(location, new Header("Want-Digest", checksum));
+
+        final Headers responseHeaders = wantDigestResponse.getHeaders();
+        assertTrue(responseHeaders.getValue(DIGEST).contains("md5") ||
+                responseHeaders.getValue(DIGEST).contains("sha"), "OK");
     }
 
     /**
@@ -436,6 +678,18 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers supporting \"redirect\" external content types MUST correctly respond to the " +
                         "\"Want-Digest\" header.",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "proxy")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPost(uri, headers));
+
+        final String checksum = "md5;q=0.3,sha;q=1";
+        final Response wantDigestResponse = doGet(location, new Header("Want-Digest", checksum));
+
+        final Headers responseHeaders = wantDigestResponse.getHeaders();
+        assertTrue(responseHeaders.getValue(DIGEST).contains("md5") ||
+                responseHeaders.getValue(DIGEST).contains("sha"), "OK");
     }
 
     /**
@@ -450,6 +704,14 @@ public class ExternalBinaryContent extends AbstractTest {
                 "A successful response to a GET request for external content with handling of redirect " +
                         "must have status code of either 302 (Found) or 307 (Temporary Redirect)",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "redirect")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPostUnverified(uri, headers));
+
+        doGet(location).then()
+                .statusCode(anyOf(is(302), is(307)));
     }
 
     /**
@@ -464,6 +726,71 @@ public class ExternalBinaryContent extends AbstractTest {
                 "A successful response to a HEAD request for external content with handling of redirect " +
                         "must have status code of either 302 (Found) or 307 (Temporary Redirect)",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
+
+        final Headers headers = new Headers(
+                new Header(LINK, externalContentHeader(externalUri, "redirect")),
+                new Header(SLUG, info.getId()));
+        final String location = getLocation(doPostUnverified(uri, headers));
+
+        doHead(location).then()
+                .statusCode(anyOf(is(302), is(307)));
     }
 
+    private boolean externalContentSupported(final String uri) {
+        if (extContentSupported == null) {
+            final String header = doOptions(uri).header("Accept-External-Content-Handling");
+            extContentSupported = header != null;
+        }
+
+        return extContentSupported;
+    }
+
+    private List<String> getAcceptedHandlingTypes(final String uri) {
+        final String header = doOptions(uri).header("Accept-External-Content-Handling");
+        if (header == null) {
+            return emptyList();
+        }
+        return Arrays.asList(header.split("\\s+,\\s+"));
+    }
+
+    private String mockHttpResource(final String filename, final String type, final String content) {
+        wireMockServer.stubFor(head(urlEqualTo("/" + filename))
+                .willReturn(aResponse()
+                        .withHeader("Content-Length", Long.toString(content.length()))
+                        .withHeader("Content-Type", type)));
+        wireMockServer.stubFor(get(urlEqualTo("/" + filename))
+                .willReturn(aResponse()
+                        .withHeader("Content-Length", Long.toString(content.length()))
+                        .withHeader("Content-Type", type)
+                        .withBody(content)));
+
+        return "http://localhost:" + wireMockServer.port() + "/" + filename;
+    }
+
+    private String mockHttpResourceNoType(final String filename, final String content) {
+        wireMockServer.stubFor(head(urlEqualTo("/" + filename))
+                .willReturn(aResponse()
+                        .withHeader("Content-Length", Long.toString(content.length()))));
+        wireMockServer.stubFor(get(urlEqualTo("/" + filename))
+                .willReturn(aResponse()
+                        .withHeader("Content-Length", Long.toString(content.length()))
+                        .withBody(content)));
+
+        return "http://localhost:" + wireMockServer.port() + "/" + filename;
+    }
+
+    private String externalContentHeader(final String uri, final String handling) {
+        return externalContentHeader(uri, handling, null);
+    }
+
+    private String externalContentHeader(final String uri, final String handling, final String type) {
+        String link = "<" + uri + ">; rel=\"" + EXTERNAL_CONTENT_LINK_REL + "\"";
+        if (handling != null) {
+            link += "; handling=\"" + handling + "\"";
+        }
+        if (type != null) {
+            link += "; type=\"" + type + "\"";
+        }
+        return link;
+    }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
@@ -70,12 +70,12 @@ public class AbstractVersioningTest extends AbstractTest {
     }
 
     protected Response putVersionedResourceUnverified(final String uri, final TestInfo info) {
-        return putVersionedResourceUnverified(uri + "/" + info.getId());
+        return putVersionedResourceUnverified(joinLocation(uri, info.getId()));
     }
 
     protected Response putVersionedResourceWithBodyUnverified(final String uri, final TestInfo info,
                                                               final String body) {
-        return putVersionedResourceWithBodyUnverified(uri + "/" + info.getId(), body);
+        return putVersionedResourceWithBodyUnverified(joinLocation(uri, info.getId()), body);
     }
 
     private Response putVersionedResourceUnverified(final String uri) {


### PR DESCRIPTION
Addresses #155 

* Adds external binary tests
* Some changes to scope of unverified method calls to allow for direct usage in tests.
* Adds mock web server for use in tests.

Fedora must be run with an allow list that permits access to your temp directory and http uris. I tested using:
`mvn jetty:run -Dfcrepo.external.content.allowed=/path/to/fcrepo4/fcrepo-http-api/src/test/resources/allowed_external_paths.txt`