### PR TITLE
152 - Cleanup resources created by tests

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -23,6 +23,7 @@ import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_BODY;
 import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_LINK_HEADER;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
 import static org.testng.AssertJUnit.assertTrue;
+import static org.fcrepo.spec.testsuite.TestSuiteGlobals.registerTestResource;
 
 import java.io.PrintStream;
 import java.io.StringReader;
@@ -161,6 +162,7 @@ public class AbstractTest {
             .post(uri);
 
         response.then().statusCode(201);
+        registerTestResource(response);
 
         return response;
     }
@@ -169,6 +171,7 @@ public class AbstractTest {
         final Response response = createDirectContainerUnverifed(uri, body);
 
         response.then().statusCode(201);
+        registerTestResource(response);
 
         return response;
     }
@@ -186,29 +189,35 @@ public class AbstractTest {
 
     protected Response doPostUnverified(final String uri, final Headers headers, final String body,
                                         final boolean admin) {
-        return createRequest(admin).headers(headers)
-                                   .body(body)
-                                   .when()
-                                   .post(uri);
+        return registerTestResource(
+                createRequest(admin)
+                        .headers(headers)
+                        .body(body)
+                        .when()
+                        .post(uri));
     }
 
     private Response doPostUnverified(final String uri, final String body) {
-        return createRequest()
-                .body(body)
-                .when()
-                .post(uri);
+        return registerTestResource(
+                createRequest()
+                        .body(body)
+                        .when()
+                        .post(uri));
     }
 
     protected Response doPostUnverified(final String uri, final Headers headers) {
-        return createRequest().headers(headers)
-                .when()
-                .post(uri);
+        return registerTestResource(
+                createRequest()
+                        .headers(headers)
+                        .when()
+                        .post(uri));
     }
 
     protected Response doPostUnverified(final String uri) {
-        return createRequest()
-                .when()
-                .post(uri);
+        return registerTestResource(
+                createRequest()
+                        .when()
+                        .post(uri));
     }
 
     protected Response doPost(final String uri, final Headers headers) {
@@ -252,21 +261,24 @@ public class AbstractTest {
 
     protected Response doPutUnverified(final String uri, final Headers headers, final String body,
                                        final boolean admin) {
-        return createRequest(admin).headers(headers)
+        return registerTestResource(
+                createRequest(admin).headers(headers)
                                    .body(body)
                                    .when()
-                                   .put(uri);
+                                   .put(uri));
     }
 
     protected Response doPutUnverified(final String uri, final Headers headers) {
-        return createRequest().headers(headers)
+        return registerTestResource(
+                createRequest().headers(headers)
                               .when()
-                              .put(uri);
+                              .put(uri));
     }
 
     protected Response doPutUnverified(final String uri) {
-        return createRequest().when()
-                              .put(uri);
+        return registerTestResource(
+                createRequest().when()
+                              .put(uri));
     }
 
     protected Response doPut(final String uri, final Headers headers) {

--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -98,7 +98,7 @@ public class App {
 
         //Create the default container
         final Map<String, String> params = new HashMap<>();
-        params.put("param1", TestSuiteGlobals.containerTestSuite(inputUrl, inputUser, inputPassword));
+        params.put("param1", TestSuiteGlobals.containerTestSuite(inputUrl, inputAdminUser, inputAdminPassword));
         params.put("param2", inputAdminUser);
         params.put("param3", inputAdminPassword);
         params.put("param4", inputUser);

--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -79,7 +79,7 @@ public class App {
         CommandLine cmd;
         try {
             cmd = parser.parse(options, args);
-        } catch (ParseException e) {
+        } catch (final ParseException e) {
             System.out.println(e.getMessage());
             formatter.printHelp("Fedora Test Suite", options);
             System.exit(1);
@@ -110,7 +110,7 @@ public class App {
         } else {
             try {
                 inputStream = new FileInputStream(inputXml);
-            } catch (FileNotFoundException e) {
+            } catch (final FileNotFoundException e) {
                 System.err.println("Unable to open '" + inputXml + "'." + e.getMessage());
                 System.exit(1);
             }
@@ -129,6 +129,10 @@ public class App {
             testng.setGroups(Joiner.on(',').join(requirements).toLowerCase());
         }
 
-        testng.run();
+        try {
+            testng.run();
+        } finally {
+            TestSuiteGlobals.cleanupTestResources();
+        }
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/ResourceCleanupManager.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/ResourceCleanupManager.java
@@ -132,7 +132,6 @@ public class ResourceCleanupManager {
                 // Remove duplicate slashes (aside from ://) due to RestAssured issue #867
                 path = path.replaceAll("(?<!:)//", "/");
                 final Response dResp = RestAssured.given()
-                        .log().all()
                         .auth().basic(user, password)
                         .when()
                         .delete(path);

--- a/src/main/java/org/fcrepo/spec/testsuite/ResourceCleanupManager.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/ResourceCleanupManager.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.spec.testsuite;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+
+/**
+ * Service which cleans up Fedora resources created by during test runs.
+ *
+ * @author bbpennel
+ */
+public class ResourceCleanupManager {
+
+    private String testContainerUrl;
+
+    private final String user;
+
+    private final String password;
+
+    private List<String> createdResources = new ArrayList<>();
+
+    /**
+     * Construct manager
+     *
+     * @param user user
+     * @param pass password
+     */
+    public ResourceCleanupManager(final String user, final String pass) {
+        this.user = user;
+        this.password = pass;
+    }
+
+    /**
+     * Add a url to the list of created fedora resources
+     *
+     * @param url url to add
+     */
+    public void registerResource(final String url) {
+        if (url != null) {
+            createdResources.add(url);
+        }
+    }
+
+    /**
+     * Cleanup the created Fedora resources.
+     */
+    public void cleanup() {
+        // Attempt to recursively delete test container to save time
+        if (testContainerUrl != null) {
+            if (cleanupTestContainer()) {
+                return;
+            }
+        }
+        // Either there was no test container, or it couldn't be recursively deleted
+        // So delete each resource in reverse order added to avoid recursion
+        Collections.reverse(createdResources);
+        // if present, register test container for deletion after all its children
+        if (testContainerUrl != null) {
+            createdResources.add(testContainerUrl);
+        }
+        cleanupResources();
+    }
+
+    private boolean cleanupTestContainer() {
+        // Determine if recursive delete allowed
+        final Response resp = RestAssured.given()
+                .auth().basic(user, password)
+                .when()
+                .options(testContainerUrl);
+
+        final String allowHeader = resp.header("Allow");
+        if (allowHeader == null || !allowHeader.contains("DELETE")) {
+            return false;
+        }
+        return deleteResource(testContainerUrl);
+    }
+
+    private void cleanupResources() {
+        for (final String resourceUrl : createdResources) {
+            deleteResource(resourceUrl);
+        }
+    }
+
+    private boolean deleteResource(final String url) {
+        final Response resp = RestAssured.given()
+                .auth().basic(user, password)
+                .when()
+                .delete(url);
+
+        if (resp.statusCode() != 204 || resp.statusCode() != 200) {
+            final PrintStream log = TestSuiteGlobals.logFile();
+            log.append("Failed to cleanup test resource: ").append(url);
+            return false;
+        } else {
+            // Also delete the tombstone if it exists
+            RestAssured.given()
+                    .auth().basic(user, password)
+                    .when()
+                    .delete(url + "/fcr:tombstone");
+        }
+        return true;
+    }
+
+    /**
+     * Set the url of the base test container.
+     *
+     * @param testContainerUrl url of the base test container
+     */
+    public void setTestContainerUrl(final String testContainerUrl) {
+        this.testContainerUrl = testContainerUrl;
+    }
+}

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -71,12 +71,11 @@ public abstract class TestSuiteGlobals {
                                         .header(SLUG, name)
                                         .when()
                                         .post(base);
-        if (res.getStatusCode() == 201) {
-            cleanupManager.setTestContainerUrl(containerUrl);
-            return containerUrl;
-        } else {
-            return base;
-        }
+        // Ensure that the container was able to be created
+        res.then().statusCode(201);
+
+        cleanupManager.setTestContainerUrl(containerUrl);
+        return containerUrl;
     }
 
     /**

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -49,6 +49,8 @@ public abstract class TestSuiteGlobals {
     private static final String[] membershipTriples = {"hasMemberRelation", "isMemberOfRelation", "membershipResource",
                                                 "insertedContentRelation"};
 
+    private static ResourceCleanupManager cleanupManager;
+
     /**
      * Get or create the default container for all tests resources to be created
      *
@@ -56,6 +58,8 @@ public abstract class TestSuiteGlobals {
      * @return containerUrl
      */
     public static String containerTestSuite(final String baseurl, final String user, final String pass) {
+        cleanupManager = new ResourceCleanupManager(user, pass);
+
         final String name = outputName + "container" + today();
         final String base = baseurl.endsWith("/") ? baseurl : baseurl + '/';
         String containerUrl = base + name + "/";
@@ -68,10 +72,22 @@ public abstract class TestSuiteGlobals {
                                         .when()
                                         .post(base);
         if (res.getStatusCode() == 201) {
+            cleanupManager.setTestContainerUrl(containerUrl);
             return containerUrl;
         } else {
             return base;
         }
+    }
+
+    public static Response registerTestResource(final Response response) {
+        if (response != null && response.statusCode() == 201) {
+            cleanupManager.registerResource(response.getHeader("Location"));
+        }
+        return response;
+    }
+
+    public static void cleanupTestResources() {
+        cleanupManager.cleanup();
     }
 
     /**

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -79,6 +79,12 @@ public abstract class TestSuiteGlobals {
         }
     }
 
+    /**
+     * Register the URI of any Fedora resource created in the given response for future cleanup.
+     *
+     * @param response response from which to register resource
+     * @return the response
+     */
     public static Response registerTestResource(final Response response) {
         if (response != null && response.statusCode() == 201) {
             cleanupManager.registerResource(response.getHeader("Location"));
@@ -86,6 +92,9 @@ public abstract class TestSuiteGlobals {
         return response;
     }
 
+    /**
+     * Deletes all Fedora resources registered for cleanup from testing.
+     */
     public static void cleanupTestResources() {
         cleanupManager.cleanup();
     }


### PR DESCRIPTION
Deletes all resources created by tests
* behavior attempts to account for possibility that a test container was not created, and whether or not the implementation supports recursive deletion of containers with children.