### PR TITLE
Implement tests in WebACGeneral

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACRepresentation.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACRepresentation.java
@@ -122,7 +122,7 @@ public class WebACRepresentation extends AbstractAuthzTest {
         //create a resource
         final Map<String,String> aclParams = new HashMap<>();
         aclParams.put("resource", resourceUri);
-        aclParams.put("groupListResource", groupListUri + "#allowed-users");
+        aclParams.put("groupListResource", groupListUri);
         createAclForResource(resourceUri, "group-authorization.ttl", aclParams);
         doGet(resourceUri, false);
     }

--- a/src/main/resources/acls/agent-group-using-hash-uris.ttl
+++ b/src/main/resources/acls/agent-group-using-hash-uris.ttl
@@ -1,5 +1,6 @@
 @prefix    acl:  <http://www.w3.org/ns/auth/acl#>.
 @prefix  vcard:  <http://www.w3.org/2006/vcard/ns#>.
-<>  a                vcard:Group;
-    vcard:hasMember  "${user}";
+<> a  acl:GroupListing .
+<#group1> a vcard:Group ;
+          vcard:hasMember  "${user}" .
 

--- a/src/main/resources/acls/everyone-read-only.ttl
+++ b/src/main/resources/acls/everyone-read-only.ttl
@@ -1,0 +1,8 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#restricted> a acl:Authorization ;
+              acl:agent foaf:Agent ;
+              acl:mode acl:Read;
+              acl:default <${resource}> ;
+              acl:accessTo <${resource}> .

--- a/src/main/resources/acls/user-read-only-access-to-child.ttl
+++ b/src/main/resources/acls/user-read-only-access-to-child.ttl
@@ -1,0 +1,8 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#restricted> a acl:Authorization ;
+              acl:agent "${user}" ;
+              acl:mode acl:Read;
+              acl:default <${defaultResource}> ;
+              acl:accessTo <${accessTo}> .

--- a/src/main/resources/acls/user-read-only-multiple-agents.ttl
+++ b/src/main/resources/acls/user-read-only-multiple-agents.ttl
@@ -1,0 +1,9 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#restricted> a acl:Authorization ;
+              acl:agent "anotheruser" ;
+              acl:agent "${user}" ;
+              acl:mode acl:Read;
+              acl:default <${resource}> ;
+              acl:accessTo <${resource}> .

--- a/src/main/resources/testng.xml
+++ b/src/main/resources/testng.xml
@@ -69,11 +69,11 @@
       <class name="org.fcrepo.spec.testsuite.authz.WebACLinkHeaders"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACRepresentation"/>
       <class name="org.fcrepo.spec.testsuite.authz.WebACRdfSources"/>
+      <class name="org.fcrepo.spec.testsuite.authz.WebACGeneral"/>
 
       <!-- Below not yet implemented -->
       <!--
       <class name="org.fcrepo.spec.testsuite.authz.WebACCrossDomain"/>
-      <class name="org.fcrepo.spec.testsuite.authz.WebACGeneral"/>
       -->
     </classes>
 


### PR DESCRIPTION
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/161

Two tests are legitimately failing.  5.0-C-B because agentGroups referenced by hash uri are not recognized. And 5.0-D because foaf:Agent is not respected.  I will create jiras.