### PR TITLE
Implements remaining tests on LdpcvHttpPost.

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/Constants.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/Constants.java
@@ -66,6 +66,8 @@ public class Constants {
 
     public static final String EXTERNAL_CONTENT_LINK_REL = "http://fedora.info/definitions/fcrepo#ExternalContent";
 
+    public static final String MEMENTO_DATETIME_HEADER = "Memento-Datetime";
+
     private Constants() {
 
     }

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
@@ -143,27 +143,33 @@ public class AbstractVersioningTest extends AbstractTest {
         Assert.assertTrue(Arrays.equals(resourceA.body().asByteArray(), resourceB.body().asByteArray()));
     }
 
-    protected void confirmResponseBodyNTriplesAreEqual(final Response resourceA, final Response resourceB) {
-
-        final String[] aTriples = resourceA.body().asString().split(".(\\r\\n|\\r|\\n)");
-        final String[] bTriples = resourceB.body().asString().split(".(\\r\\n|\\r|\\n)");
-
+    protected void confirmResponseBodyNTriplesAreEqual(final String responseBodyA, final String responseBodyB) {
+        final String[] aTriples = responseBodyA.split(".(\\r\\n|\\r|\\n)");
+        final String[] bTriples = responseBodyB.split(".(\\r\\n|\\r|\\n)");
         sort(aTriples);
         sort(bTriples);
-
         Assert.assertTrue(Arrays.equals(aTriples, bTriples));
+    }
+
+    protected void confirmResponseBodyNTriplesAreEqual(final Response resourceA, final Response resourceB) {
+        confirmResponseBodyNTriplesAreEqual(resourceA.getBody().asString(), resourceB.getBody().asString());
     }
 
     /**
      * Given the URI of the original resource, create a memento based on the
-     * current state of the reosurce.
+     * specified body.
      * @param originalResourceUri The resource to be memento-ized.
-     * @return
+     * @param mementoDateTime the memento datetime
+     * @param contentType the content Type of the memento
+     * @param body the body of the memento
+     * @return The uri of the newly created memento
      */
-    protected String createMemento(final String originalResourceUri, final String mementoDateTime, final String body) {
+    protected String createMemento(final String originalResourceUri, final String mementoDateTime,
+                                   final String contentType, final String body) {
         final Response response = doGet(originalResourceUri);
         final URI timeMapURI = getTimeMapUri(response);
-        final Headers headers = new Headers(new Header(MEMENTO_DATETIME_HEADER, mementoDateTime));
+        final Headers headers = new Headers(new Header("Content-Type", contentType),
+                                            new Header(MEMENTO_DATETIME_HEADER, mementoDateTime));
 
         final Response timeMapResponse = doPost(timeMapURI.toString(),headers, body);
         return getLocation(timeMapResponse);

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
@@ -20,7 +20,9 @@ package org.fcrepo.spec.testsuite.versioning;
 
 import static java.util.Arrays.sort;
 import static org.fcrepo.spec.testsuite.Constants.CONTENT_DISPOSITION;
+import static org.fcrepo.spec.testsuite.Constants.MEMENTO_DATETIME_HEADER;
 import static org.fcrepo.spec.testsuite.Constants.ORIGINAL_RESOURCE_LINK_HEADER;
+import static org.testng.AssertJUnit.assertEquals;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -116,6 +118,12 @@ public class AbstractVersioningTest extends AbstractTest {
 
     }
 
+    protected void confirmPresenceOfMementoDatetimeHeader(final String mementoDateTime, final Response response) {
+        final String dateTime = response.getHeader(MEMENTO_DATETIME_HEADER);
+        assertEquals(mementoDateTime, dateTime, "Memento-Datetime header does not match expected");
+    }
+
+
     protected void confirmPresenceOfVersionLocationHeader(final Response response) {
         final String location = response.getHeader("Location");
         Assert.assertTrue(location.contains("fcr:versions"));
@@ -152,11 +160,19 @@ public class AbstractVersioningTest extends AbstractTest {
      * @param originalResourceUri The resource to be memento-ized.
      * @return
      */
+    protected String createMemento(final String originalResourceUri, final String mementoDateTime, final String body) {
+        final Response response = doGet(originalResourceUri);
+        final URI timeMapURI = getTimeMapUri(response);
+        final Headers headers = new Headers(new Header(MEMENTO_DATETIME_HEADER, mementoDateTime));
+
+        final Response timeMapResponse = doPost(timeMapURI.toString(),headers, body);
+        return getLocation(timeMapResponse);
+    }
+
     protected String createMemento(final String originalResourceUri) {
         final Response response = doGet(originalResourceUri);
         final URI timeMapURI = getTimeMapUri(response);
         final Response timeMapResponse = doPost(timeMapURI.toString());
         return getLocation(timeMapResponse);
     }
-
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
@@ -17,11 +17,15 @@
  */
 package org.fcrepo.spec.testsuite.versioning;
 
+import static org.fcrepo.spec.testsuite.Constants.MEMENTO_DATETIME_HEADER;
 import static org.fcrepo.spec.testsuite.Constants.MEMENTO_LINK_HEADER;
+import static org.testng.AssertJUnit.fail;
+
+import java.net.URI;
 
 import io.restassured.http.Header;
+import io.restassured.http.Headers;
 import io.restassured.response.Response;
-import java.net.URI;
 import org.fcrepo.spec.testsuite.TestInfo;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -51,8 +55,8 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void ldpcvOfLdprsMustSupportPostWithoutMementoDatetimeHeader(final String uri) {
-        final TestInfo info = setupTest("4.3.3.1-A", "ldpcvOfLdprsMustSupportPostWithoutMementoDatetimeHeader",
+    public void ldpcvOfLdprsShouldSupportPostWithoutMementoDatetimeHeader(final String uri) {
+        final TestInfo info = setupTest("4.3.3.1-A", "ldpcvOfLdprsShouldSupportPostWithoutMementoDatetimeHeader",
                                         "If an LDPCv of an LDP-RS supports POST, a POST request that does not contain" +
                                         " a Memento-Datetime header should be understood to create a new LDPRm " +
                                         "contained by the LDPCv, reflecting the state of the LDPRv at the time of " +
@@ -92,8 +96,8 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
      */
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
-    public void ldpcvOfLdpnrsMustSupportPostWithoutMementoDatetimeHeader(final String uri) {
-        final TestInfo info = setupTest("4.3.3.1-B", "ldpcvOfLdpnrsMustSupportPostWithoutMementoDatetimeHeader",
+    public void ldpcvOfLdpnrsShouldSupportPostWithoutMementoDatetimeHeader(final String uri) {
+        final TestInfo info = setupTest("4.3.3.1-B", "ldpcvOfLdpnrsShouldSupportPostWithoutMementoDatetimeHeader",
                                         "If an LDPCv of an LDP-NR supports POST, a POST request that does not contain" +
                                         " a Memento-Datetime header should be understood to create a new LDPRm " +
                                         "contained by the LDPCv, reflecting the state of the LDPRv at the time of " +
@@ -205,7 +209,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
      *
      * @param uri The repository root URI
      */
-    // @Test(groups = {"SHOULD"})
+    @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void postToldpcvOfLdprWithMementoDatetimeShouldCreateNewResource(final String uri) {
         final TestInfo info = setupTest("4.3.3.1-E", "postToldpcvOfLdprWithMementoDatetimeShouldCreateNewResource",
@@ -214,7 +218,21 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
                                         "state given in the request body.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
                                         ps);
+        //create a versioned resource
+        final Response createResponse = createVersionedResource(uri, info);
+        //if post is supported on the ldpcv
+        // get the new resource, which should have all the proper memento headers
+        final String originalResource = getLocation(createResponse);
+        final Response originalResponse = doGet(originalResource);
+        final String body = originalResponse.getBody().asString();
+        final URI timeMapURI = getTimeMapUri(originalResponse);
+        if (hasHeaderValueInMultiValueHeader("Allow", "POST", doGet(timeMapURI.toString()))) {
+            //create a memento using the Memento-Datetime and a body
+            final String mementoUri = createMemento(originalResource, "Sat, 1 Jan 2000 00:00:00 GMT", body);
+            // is the memento exactly the same as the original?
+            confirmResponseBodyNTriplesAreEqual(originalResponse, doGet(mementoUri));
 
+        }
     }
 
     /**
@@ -222,7 +240,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
      *
      * @param uri The repository root URI
      */
-    //@Test(groups = {"SHOULD"})
+    @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void mementoDatetimeHeaderShouldMatchThatUsedWhenMementoCreated(final String uri) {
         final TestInfo info = setupTest("4.3.3.1-F", "mementoDatetimeHeaderShouldMatchThatUsedWhenMementoCreated",
@@ -232,6 +250,22 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
                                         ps);
 
+        final String mementoDateTime = "Sat, 1 Jan 2000 00:00:00 GMT";
+        //create a versioned resource
+        final Response createResponse = createVersionedResource(uri, info);
+        //if post is supported on the ldpcv
+        // get the new resource, which should have all the proper memento headers
+        final String originalResource = getLocation(createResponse);
+        final Response originalResponse = doGet(originalResource);
+        final String body = originalResponse.getBody().asString();
+        final URI timeMapURI = getTimeMapUri(originalResponse);
+        if (hasHeaderValueInMultiValueHeader("Allow", "POST", doGet(timeMapURI.toString()))) {
+            //create a memento using the Memento-Datetime and a body
+            final String mementoUri = createMemento(originalResource, mementoDateTime, body);
+            //verify Memento-Datetime- is in the request header
+            confirmPresenceOfMementoDatetimeHeader(mementoDateTime, doGet(mementoUri));
+        }
+
     }
 
     /**
@@ -239,7 +273,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
      *
      * @param uri The repository root URI
      */
-    //@Test(groups = {"MUST"})
+    @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvDoesNotSupportPost(final String uri) {
         final TestInfo info = setupTest("4.3.3.2", "ldpcvDoesNotSupportPost",
@@ -249,6 +283,29 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-post",
                                         ps);
 
+        final Response createResponse = createVersionedResource(uri, info);
+        final String originalResource = getLocation(createResponse);
+        final Response originalResponse = doGet(originalResource);
+        final String timeMapURI = getTimeMapUri(originalResponse).toString();
+        final Response getResponse = doGet(timeMapURI);
+        if (!hasHeaderValueInMultiValueHeader("Allow", "POST", getResponse)) {
+            //if post is supported on the ldpcv, try posting
+            final Response postResponse = doPostUnverified(timeMapURI);
+            //verify correct error range
+            postResponse.then().statusCode(clientErrorRange());
+            //verify presence of constraints link
+            confirmPresenceOfConstrainedByLink(postResponse);
+        } else {
+            //if it supports post but not with the Memento-Datetime header
+            if (!hasHeaderValueInMultiValueHeader("Vary-Post", MEMENTO_DATETIME_HEADER, getResponse)) {
+                final Response postResponse = doPostUnverified(timeMapURI, new Headers(
+                    new Header(MEMENTO_DATETIME_HEADER, "Sat, 1 Jan 2000 00:00:00 GMT")));
+                //verify correct error range
+                postResponse.then().statusCode(clientErrorRange());
+                //verify presence of constraints link
+                confirmPresenceOfConstrainedByLink(postResponse);
+            }
+        }
     }
 
     /**
@@ -256,13 +313,22 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
      *
      * @param uri The repository root URI
      */
-    //@Test(groups = {"MAY"})
+    @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMayDisallowPut(final String uri) {
         final TestInfo info = setupTest("4.3.4", "ldpcvMayDisallowPut",
                                         "Implementations MAY disallow PUT.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-put",
                                         ps);
+
+        final Response createResponse = createVersionedResource(uri, info);
+        final String originalResource = getLocation(createResponse);
+        final Response originalResponse = doGet(originalResource);
+        final String timeMapURI = getTimeMapUri(originalResponse).toString();
+        final Response getResponse = doGet(timeMapURI);
+        if (hasHeaderValueInMultiValueHeader("Allow", "PUT", getResponse)) {
+            fail("This Fedora implementation allows PUTs on LDPCv.");
+        }
 
     }
 
@@ -271,13 +337,21 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
      *
      * @param uri The repository root URI
      */
-    //@Test(groups = {"MAY"})
+    @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMayDisallowPatch(final String uri) {
         final TestInfo info = setupTest("4.3.5", "ldpcvMayDisallowPatch",
                                         "Implementations MAY disallow PATCH",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-patch",
                                         ps);
+        final Response createResponse = createVersionedResource(uri, info);
+        final String originalResource = getLocation(createResponse);
+        final Response originalResponse = doGet(originalResource);
+        final String timeMapURI = getTimeMapUri(originalResponse).toString();
+        final Response getResponse = doGet(timeMapURI);
+        if (hasHeaderValueInMultiValueHeader("Allow", "PATCH", getResponse)) {
+            fail("This Fedora implementation allows PUTs on LDPCv.");
+        }
 
     }
 

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
@@ -224,13 +224,16 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
         // get the new resource, which should have all the proper memento headers
         final String originalResource = getLocation(createResponse);
         final Response originalResponse = doGet(originalResource);
-        final String body = originalResponse.getBody().asString();
+        //get the original resource and add a triple
+        final String body =
+            originalResponse.getBody().asString() + "\n<" + originalResource + "> dc:description \"test\" .";
         final URI timeMapURI = getTimeMapUri(originalResponse);
         if (hasHeaderValueInMultiValueHeader("Allow", "POST", doGet(timeMapURI.toString()))) {
             //create a memento using the Memento-Datetime and a body
-            final String mementoUri = createMemento(originalResource, "Sat, 1 Jan 2000 00:00:00 GMT", body);
-            // is the memento exactly the same as the original?
-            confirmResponseBodyNTriplesAreEqual(originalResponse, doGet(mementoUri));
+            final String mementoUri =
+                createMemento(originalResource, "Sat, 1 Jan 2000 00:00:00 GMT", "text/turtle", body);
+            // is the memento exactly the same as provided?
+            confirmResponseBodyNTriplesAreEqual(body, doGet(mementoUri).getBody().asString());
 
         }
     }
@@ -261,7 +264,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
         final URI timeMapURI = getTimeMapUri(originalResponse);
         if (hasHeaderValueInMultiValueHeader("Allow", "POST", doGet(timeMapURI.toString()))) {
             //create a memento using the Memento-Datetime and a body
-            final String mementoUri = createMemento(originalResource, mementoDateTime, body);
+            final String mementoUri = createMemento(originalResource, mementoDateTime, "text/turtle", body);
             //verify Memento-Datetime- is in the request header
             confirmPresenceOfMementoDatetimeHeader(mementoDateTime, doGet(mementoUri));
         }
@@ -326,10 +329,10 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
         final Response originalResponse = doGet(originalResource);
         final String timeMapURI = getTimeMapUri(originalResponse).toString();
         final Response getResponse = doGet(timeMapURI);
-        if (hasHeaderValueInMultiValueHeader("Allow", "PUT", getResponse)) {
+        if (hasHeaderValueInMultiValueHeader("Allow", "PUT", getResponse)
+            || doPutUnverified(timeMapURI).statusCode() != 405) {
             fail("This Fedora implementation allows PUTs on LDPCv.");
         }
-
     }
 
     /**
@@ -349,8 +352,9 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
         final Response originalResponse = doGet(originalResource);
         final String timeMapURI = getTimeMapUri(originalResponse).toString();
         final Response getResponse = doGet(timeMapURI);
-        if (hasHeaderValueInMultiValueHeader("Allow", "PATCH", getResponse)) {
-            fail("This Fedora implementation allows PUTs on LDPCv.");
+        if (hasHeaderValueInMultiValueHeader("Allow", "PATCH", getResponse)
+            || doPatchUnverified(timeMapURI).statusCode() != 405) {
+            fail("This Fedora implementation allows PATCHs on LDPCv.");
         }
 
     }


### PR DESCRIPTION
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/169

4.3.3.1-E and 4.3.3.1-F should pass once  https://jira.duraspace.org/browse/FCREPO-2848 is complete.