### PR TITLE
CTS-196 - Added test for the possibility of allowing interaction models to change

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
@@ -51,23 +51,46 @@ public class HttpPut extends AbstractTest {
     }
 
     /**
+     * 3.6-A
+     *
+     * @param uri The repository root URI
+     */
+    @Test(groups = {"MAY"})
+    @Parameters({"param1"})
+    public void httpPutChangeTypeAllowed(final String uri) {
+        final TestInfo info = setupTest("3.6-A", "httpPutChangeTypeAllowed",
+                "Implementations MAY allow the interaction model of an existing " +
+                        "resource to be changed by specification of a new LDP type in a " +
+                        "rel=\"type\" link in the HTTP Link header",
+                "https://fcrepo.github.io/fcrepo-specification/#http-put", ps);
+
+        final Headers headers = new Headers(
+                new Header("Link", "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\""),
+                new Header(SLUG, info.getId()));
+        final Response resource = doPost(uri, headers);
+
+        final String locationHeader = getLocation(resource);
+        final Headers headers1 = new Headers(
+                new Header("Link", "<http://www.w3.org/ns/ldp#DirectContainer>; rel=\"type\""));
+        doPutUnverified(locationHeader, headers1)
+                .then()
+                .statusCode(successRange());
+    }
+
+    /**
      * 3.6-B
      *
      * @param uri The repository root URI
      */
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
-    public void httpPut(final String uri) {
-        final TestInfo info = setupTest("3.6-B", "httpPut",
+    public void httpPutChangeTypeNotAllowed(final String uri) {
+        final TestInfo info = setupTest("3.6-B", "httpPutChangeTypeNotAllowed",
                                         "When accepting a PUT request against an existant resource, an HTTP Link: " +
-                                        "rel=\"type\" header "
-                                        +
-                                        "may be included. If that type is a value in the LDP namespace and is not " +
-                                        "either a current "
-                                        +
-                                        "type of the resource or a subtype of a current type of the resource, the " +
-                                        "request must be "
-                                        + "rejected with a 409 Conflict response.",
+                                        "rel=\"type\" header may be included. If that type is a value in the LDP " +
+                                        "namespace and is not either a current type of the resource or a subtype " +
+                                        "of a current type of the resource, the request must be " +
+                                        "rejected with a 409 Conflict response.",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-put", ps);
         final Headers headers = new Headers(
                 new Header(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\""),
@@ -90,7 +113,7 @@ public class HttpPut extends AbstractTest {
      */
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
-    public void httpPutpdateTriples(final String uri) {
+    public void httpPutUpdateTriples(final String uri) {
         final TestInfo info = setupTest("3.6.1-A", "httpPutpdateTriples",
                                         "Any LDP-RS must support PUT to update statements that are not server-managed" +
                                         " triples (as defined "

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
@@ -65,13 +65,13 @@ public class HttpPut extends AbstractTest {
                 "https://fcrepo.github.io/fcrepo-specification/#http-put", ps);
 
         final Headers headers = new Headers(
-                new Header("Link", "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\""),
+                new Header("Link", "<http://www.w3.org/ns/ldp#RDFSource>; rel=\"type\""),
                 new Header(SLUG, info.getId()));
         final Response resource = doPost(uri, headers);
 
         final String locationHeader = getLocation(resource);
         final Headers headers1 = new Headers(
-                new Header("Link", "<http://www.w3.org/ns/ldp#DirectContainer>; rel=\"type\""));
+                new Header("Link", "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\""));
         doPutUnverified(locationHeader, headers1)
                 .then()
                 .statusCode(successRange());

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
@@ -114,7 +114,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPutUpdateTriples(final String uri) {
-        final TestInfo info = setupTest("3.6.1-A", "httpPutpdateTriples",
+        final TestInfo info = setupTest("3.6.1-A", "httpPutUpdateTriples",
                                         "Any LDP-RS must support PUT to update statements that are not server-managed" +
                                         " triples (as defined "
                                         + "in [LDP] 2). [LDP] 4.2.4.1 and 4.2.4.3 remain in effect.",


### PR DESCRIPTION
This test fails because it seems like we do not allow for interaction models to be changed in the community implementation. Or if we do I'm not sure what models are allowed to be changed between (versus adding new ones). The constraint document returned by the request isn't clarifying things too much:
https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-webapp/src/main/webapp/static/constraints/InteractionModelViolationException.rdf
and the behavior is not defined very well in the LDP spec (since its allowed as an extension, but not defined)

Alternatively, we could leave the stubbed out method there so we know that there is a test that needs to be filled in in the future when we have a case that can pass.