### PR TITLE
Automate test method name setting

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -124,6 +124,22 @@ public class AbstractTest {
     }
 
     /**
+     * A convenience method for setup boilerplate which attempts to automatically
+     * set the name of the test method which directly invoked this setup.
+     */
+    protected TestInfo setupTest(final String id, final String description, final String specLink,
+            final PrintStream ps) {
+
+        // Test method should be the previous method in the stack trace.
+        final StackTraceElement[] trace = new Throwable().getStackTrace();
+        if (trace.length <= 1) {
+            throw new RuntimeException("Cannot determine test method name, " +
+                    "specify directly using title parameter in the other setupTest signature");
+        }
+        return setupTest(id, trace[1].getMethodName(), description, specLink, ps);
+    }
+
+    /**
      * A convenience method for setup boilerplate
      */
     protected TestInfo setupTest(final String id, final String title, final String description, final String specLink,

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACCrossDomain.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACCrossDomain.java
@@ -48,7 +48,7 @@ public class WebACCrossDomain extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void restrictAclToLocal(final String uri) {
-        final TestInfo info = setupTest("5.5-A", "restrictAclToLocal",
+        final TestInfo info = setupTest("5.5-A",
                 "Implementations may restrict support for ACLs to local resources.",
                 "https://fedora.info/2018/06/25/spec/#cross-domain-acls", ps);
     }
@@ -61,7 +61,7 @@ public class WebACCrossDomain extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void rejectRemoteAclStatus(final String uri) {
-        final TestInfo info = setupTest("5.5-B", "rejectRemoteAclStatus",
+        final TestInfo info = setupTest("5.5-B",
                 "If an implementation chooses to reject requests concerning remote ACLs, it must respond with a " +
                         "4xx range status code.",
                 "https://fedora.info/2018/06/25/spec/#cross-domain-acls", ps);
@@ -75,7 +75,7 @@ public class WebACCrossDomain extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void rejectRemoteAclConstraint(final String uri) {
-        final TestInfo info = setupTest("5.5-C", "rejectRemoteAclConstraint",
+        final TestInfo info = setupTest("5.5-C",
                 "If an implementation chooses to reject requests concerning remote ACLs, it must advertise the " +
                         "restriction with a rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link in the Link " +
                         "response header.",
@@ -90,7 +90,7 @@ public class WebACCrossDomain extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void restrictGroupToLocal(final String uri) {
-        final TestInfo info = setupTest("5.6-A", "restrictGroupToLocal",
+        final TestInfo info = setupTest("5.6-A",
                 "Implementations may restrict support for groups of agents to local Group Listing documents.",
                 "https://fedora.info/2018/06/25/spec/#cross-domain-groups", ps);
     }
@@ -103,7 +103,7 @@ public class WebACCrossDomain extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void rejectRemoteGroupStatus(final String uri) {
-        final TestInfo info = setupTest("5.6-B", "rejectRemoteGroupStatus",
+        final TestInfo info = setupTest("5.6-B",
                 "If an implementation chooses to reject requests concerning remote Group Listings, it must respond " +
                         "with a 4xx range status code.",
                 "https://fedora.info/2018/06/25/spec/#cross-domain-groups", ps);
@@ -117,7 +117,7 @@ public class WebACCrossDomain extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void rejectRemoteGroupConstraint(final String uri) {
-        final TestInfo info = setupTest("5.6-C", "rejectRemoteGroupConstraint",
+        final TestInfo info = setupTest("5.6-C",
                 "If an implementation chooses to reject requests concerning remote Group Listings, it must advertise " +
                         "the restriction with a rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link in the Link " +
                         "response header.",

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACGeneral.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACGeneral.java
@@ -55,7 +55,7 @@ public class WebACGeneral extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void agentSingle(final String uri) {
-        final TestInfo info = setupTest("5.0-A", "agentSingle",
+        final TestInfo info = setupTest("5.0-A",
                                         "An authorization may list any number of individual agents (that are being " +
                                         "given access) by using " +
                                         "the acl:agent predicate",
@@ -74,7 +74,7 @@ public class WebACGeneral extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void agentDouble(final String uri) {
-        final TestInfo info = setupTest("5.0-B", "agentDouble",
+        final TestInfo info = setupTest("5.0-B",
                                         "An authorization may list any number of individual agents (that are being " +
                                         "given access) by using " +
                                         "the acl:agent predicate.",
@@ -92,7 +92,7 @@ public class WebACGeneral extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void agentGroup(final String uri) {
-        final TestInfo info = setupTest("5.0-C-A", "agentGroup",
+        final TestInfo info = setupTest("5.0-C-A",
                                         "To give access to a group of agents, use the acl:agentGroup predicate. The " +
                                         "object of an " +
                                         "agentGroup statement is a link to a Group Listing document. The group " +
@@ -128,7 +128,7 @@ public class WebACGeneral extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void agentGroupWithHashUris(final String uri) {
-        final TestInfo info = setupTest("5.0-C-B", "agentGroupWithHashUris",
+        final TestInfo info = setupTest("5.0-C-B",
                                         "To give access to a group of agents, use the acl:agentGroup predicate. The " +
                                         "object of an " +
                                         "agentGroup statement is a link to a Group Listing document. The group " +
@@ -165,7 +165,7 @@ public class WebACGeneral extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void agentAll(final String uri) {
-        final TestInfo info = setupTest("5.0-D", "agentAll",
+        final TestInfo info = setupTest("5.0-D",
                                         "To specify that you're giving a particular mode of access to everyone, you " +
                                         "can use acl:agentClass " +
                                         "foaf:Agent to denote that you're giving access to the class of all agents " +
@@ -185,7 +185,7 @@ public class WebACGeneral extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void allAuthenticatedAgents(final String uri) {
-        final TestInfo info = setupTest("5.0-E", "allAuthenticatedAgents",
+        final TestInfo info = setupTest("5.0-E",
                                         "To specify that you're giving a particular mode of access to all " +
                                         "authenticated users, you can use acl:agentClass acl:AuthenticatedAgent to " +
                                         "denote that you're giving access to the class of all authenticated agents.",
@@ -206,7 +206,7 @@ public class WebACGeneral extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void resourceSingle(final String uri) {
-        final TestInfo info = setupTest("5.0-F", "resourceSingle",
+        final TestInfo info = setupTest("5.0-F",
                                         "The acl:accessTo predicate specifies which resources you're giving access " +
                                         "to, using their URLs as " +
                                         "the subjects.",

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACLinkHeaders.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACLinkHeaders.java
@@ -51,7 +51,7 @@ public class WebACLinkHeaders extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void linkToAclExisting(final String uri) {
-        final TestInfo info = setupTest("5.3-A", "linkToAclExisting",
+        final TestInfo info = setupTest("5.3-A",
                                         "A conforming server must advertise the individual resource ACL for every " +
                                         "controlled resource in HTTP responses with a rel=\"acl\" link in the Link " +
                                         "header, whether or not the ACL exists.",
@@ -75,7 +75,7 @@ public class WebACLinkHeaders extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void linkToAclNonexisting(final String uri) {
-        final TestInfo info = setupTest("5.3-B", "linkToAclNonexisting",
+        final TestInfo info = setupTest("5.3-B",
                                         "A conforming server must advertise the individual resource ACL for every " +
                                         "controlled resource in HTTP responses with a rel=\"acl\" link in the Link " +
                                         "header, whether or not the ACL exists.",
@@ -95,7 +95,7 @@ public class WebACLinkHeaders extends AbstractAuthzTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void aclOnSameServer(final String uri) {
-        final TestInfo info = setupTest("5.3-C", "aclOnSameServer",
+        final TestInfo info = setupTest("5.3-C",
                                         "The ACL resource should be located in the same server as the controlled " +
                                         "resource.",
                                         "https://fedora.info/2018/06/25/spec/#link-rel-acl", ps);

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACLinking.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACLinking.java
@@ -50,7 +50,7 @@ public class WebACLinking extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void linkToAclOnCreation(final String uri) {
-        final TestInfo info = setupTest("5.4-A", "linkToAclOnCreation",
+        final TestInfo info = setupTest("5.4-A",
                                         "A client HTTP POST or PUT request to create a new LDPR may include a " +
                                         "rel=\"acl\" link in the " +
                                         "Link header referencing an existing LDP-RS to use as the ACL for the new " +
@@ -78,7 +78,7 @@ public class WebACLinking extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void conflictIfNotSupportingAclLink(final String uri) {
-        final TestInfo info = setupTest("5.4-B", "conflictIfNotSupportingAclLink",
+        final TestInfo info = setupTest("5.4-B",
                                         "The server must reject the request and respond with a 4xx or 5xx range " +
                                         "status code, such as " +
                                         "409 (Conflict) if it isn't able to create the LDPR with the specified LDP-RS" +

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -55,7 +55,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void readAllowedHEAD(final String uri) {
-        final TestInfo info = setupTest("5.0-F", "readAllowedHEAD",
+        final TestInfo info = setupTest("5.0-F",
                                         "acl:Read gives access to a class of operations that can be described as " +
                                         "\"Read Access\". " +
                                         "In a typical REST API, this includes access to HTTP verbs HEAD.",
@@ -76,7 +76,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void readAllowedGET(final String uri) {
-        final TestInfo info = setupTest("5.0-G", "readAllowedGET",
+        final TestInfo info = setupTest("5.0-G",
                                         "acl:Read gives access to a class of operations that can be described as " +
                                         "\"Read Access\". " +
                                         "In a typical REST API, this includes access to HTTP verbs GET.",
@@ -96,7 +96,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void readDisallowed(final String uri) {
-        final TestInfo info = setupTest("5.0-H", "readDisallowed",
+        final TestInfo info = setupTest("5.0-H",
                                         "acl:Read gives access to a class of operations that can be described as " +
                                         "\"Read Access\". " +
                                         "In a typical REST API, this includes access to HTTP verbs GET. Its absence " +
@@ -120,7 +120,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void writeAllowedPUT(final String uri) {
-        final TestInfo info = setupTest("5.0-I", "writeAllowedPUT",
+        final TestInfo info = setupTest("5.0-I",
                                         "acl:Write gives access to a class of operations that can modify the resource" +
                                         ". In a REST API " +
                                         "context, this would include PUT.",
@@ -146,7 +146,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void writeAllowedPOST(final String uri) {
-        final TestInfo info = setupTest("5.0-J", "writeAllowedPOST",
+        final TestInfo info = setupTest("5.0-J",
                                         "acl:Write gives access to a class of operations that can modify the resource" +
                                         ". In a REST API " +
                                         "context, this would include POST.",
@@ -168,7 +168,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void writeAllowedDELETE(final String uri) {
-        final TestInfo info = setupTest("5.0-K", "writeAllowedDELETE",
+        final TestInfo info = setupTest("5.0-K",
                                         "acl:Write gives access to a class of operations that can modify the resource" +
                                         ". In a REST API " +
                                         "context, this would include DELETE",
@@ -188,7 +188,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void writeAllowedPATCH(final String uri) {
-        final TestInfo info = setupTest("5.0-L", "writeAllowedPATCH",
+        final TestInfo info = setupTest("5.0-L",
                                         "acl:Write gives access to a class of operations that can modify the resource" +
                                         ". In a REST API " +
                                         "context, this would include PATCH.",
@@ -215,7 +215,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void writeDisallowedPut(final String uri) {
-        final TestInfo info = setupTest("5.0-M-1", "writeDisallowedPut",
+        final TestInfo info = setupTest("5.0-M-1",
                                         "acl:Write gives access to PUT a resource. When not present, " +
                                         "writes should be disallowed.",
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
@@ -239,7 +239,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void writeDisallowedPost(final String uri) {
-        final TestInfo info = setupTest("5.0-M-2", "writeDisallowedPost",
+        final TestInfo info = setupTest("5.0-M-2",
                                         "acl:Write gives access to POST a resource. When not present, " +
                                         "writes should be disallowed.",
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
@@ -260,7 +260,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void writeDisallowedDelete(final String uri) {
-        final TestInfo info = setupTest("5.0-M-3", "writeDisallowedDelete",
+        final TestInfo info = setupTest("5.0-M-3",
                                         "acl:Write gives access to DELETE a resource. When not present, " +
                                         "writes should be disallowed.",
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
@@ -280,7 +280,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void writeDisallowedPatch(final String uri) {
-        final TestInfo info = setupTest("5.0-M-4", "writeDisallowedPatch",
+        final TestInfo info = setupTest("5.0-M-4",
                                         "acl:Write gives access to PATCH a resource. When not present, " +
                                         "writes should be disallowed.",
                                         "https://fedora.info/2018/06/25/spec/#resource-authorization", ps);
@@ -308,7 +308,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void appendAllowedPOST(final String uri) {
-        final TestInfo info = setupTest("5.0-N", "appendAllowedPOST",
+        final TestInfo info = setupTest("5.0-N",
                                         "acl:Append gives a more limited ability to write to a resource -- " +
                                         "Append-Only. " +
                                         "This generally includes the HTTP verb POST.",
@@ -330,7 +330,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void appendAllowedPATCH(final String uri) {
-        final TestInfo info = setupTest("5.0-O", "appendAllowedPATCH",
+        final TestInfo info = setupTest("5.0-O",
                                         "acl:Append gives a more limited ability to write to a resource -- " +
                                         "Append-Only. " +
                                         "This generally includes the INSERT-only portion of SPARQL-based PATCHes.",
@@ -355,7 +355,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void appendDisallowed(final String uri) {
-        final TestInfo info = setupTest("5.0-P", "appendDisallowed",
+        final TestInfo info = setupTest("5.0-P",
                                         "acl:Append gives a more limited ability to write to a resource -- " +
                                         "Append-Only. " +
                                         "This generally includes the HTTP verb POST, although some implementations " +
@@ -387,7 +387,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void controlAllowedGET(final String uri) {
-        final TestInfo info = setupTest("5.0-Q", "controlAllowedGET",
+        final TestInfo info = setupTest("5.0-Q",
                                         "acl:Control is a special-case access mode that gives an agent the ability to" +
                                         " view the ACL of a " +
                                         "resource.",
@@ -407,7 +407,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void controlAllowedPATCH(final String uri) {
-        final TestInfo info = setupTest("5.0-R", "controlAllowedPATCH",
+        final TestInfo info = setupTest("5.0-R",
                                         "acl:Control is a special-case access mode that gives an agent the ability to" +
                                         " modify the ACL of a " +
                                         "resource.",
@@ -433,7 +433,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void controlAllowedPUT(final String uri) {
-        final TestInfo info = setupTest("5.0-S", "controlAllowedPUT",
+        final TestInfo info = setupTest("5.0-S",
                                         "acl:Control is a special-case access mode that gives an agent the ability to" +
                                         " modify the ACL of a " +
                                         "resource.",
@@ -464,7 +464,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void controlDisallowedGET(final String uri) {
-        final TestInfo info = setupTest("5.0-T", "controlDisallowedGET",
+        final TestInfo info = setupTest("5.0-T",
                                         "acl:Control is a special-case access mode that gives an agent the ability to" +
                                         " view and modify the " +
                                         "ACL of a resource. Its absence must prevent viewing the ACL.",
@@ -485,7 +485,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void controlDisallowedPATCH(final String uri) {
-        final TestInfo info = setupTest("5.0-U", "controlDisallowedPATCH",
+        final TestInfo info = setupTest("5.0-U",
                                         "acl:Control is a special-case access mode that gives an agent the ability to" +
                                         " view and modify the " +
                                         "ACL of a resource. Its absence must prevent updating the ACL.",
@@ -514,7 +514,7 @@ public class WebACModes extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void controlDisallowedPUT(final String uri) {
-        final TestInfo info = setupTest("5.0-U", "controlDisallowedPUT",
+        final TestInfo info = setupTest("5.0-U",
                                         "acl:Control is a special-case access mode that gives an agent the ability to" +
                                         " view and modify the " +
                                         "ACL of a resource. Its absence must prevent updating the ACL.",

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACRdfSources.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACRdfSources.java
@@ -52,7 +52,7 @@ public class WebACRdfSources extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void aclIsLDPRS(final String uri) {
-        final TestInfo info = setupTest("5.1", "aclIsLDPRS",
+        final TestInfo info = setupTest("5.1",
                                         "An ACL for a controlled resource on a conforming server must itself be an " +
                                         "LDP-RS.",
                                         "https://fedora.info/2018/06/25/spec/#solid-ldp-acls", ps);

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACRepresentation.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACRepresentation.java
@@ -54,7 +54,7 @@ public class WebACRepresentation extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void aclRepresentation(final String uri) {
-        final TestInfo info = setupTest("5.2-A", "aclRepresentation",
+        final TestInfo info = setupTest("5.2-A",
                                         "Implementations must inspect the ACL RDF for authorizations. Authorizations " +
                                         "are identified by type definition triples of the form authorization_N " +
                                         "rdf:type acl:Authorization, where authorization_N is the URI of an " +
@@ -76,7 +76,7 @@ public class WebACRepresentation extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void onlyAuthorizationStatementsUsed(final String uri) {
-        final TestInfo info = setupTest("5.2-B", "onlyAuthorizationStatementsUsed",
+        final TestInfo info = setupTest("5.2-B",
                                         "Implementations must use only statements associated with an authorization in" +
                                         " the ACL RDF to determine access, except in the case of acl:agentGroup " +
                                         "statements where the group listing document is dereferenced.",
@@ -100,7 +100,7 @@ public class WebACRepresentation extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void dereferencingGroups(final String uri) {
-        final TestInfo info = setupTest("5.2-C", "dereferencingGroups",
+        final TestInfo info = setupTest("5.2-C",
                 "Implementations must use only statements associated with an authorization in the ACL RDF to " +
                         "determine access, except in the case of acl:agentGroup statements where the group listing " +
                         "document is dereferenced.",
@@ -135,7 +135,7 @@ public class WebACRepresentation extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void aclExamined(final String uri) {
-        final TestInfo info = setupTest("5.2-D", "aclExamined",
+        final TestInfo info = setupTest("5.2-D",
                                         "The authorizations must be examined to see whether they grant the requested " +
                                         "access to the controlled resource.",
                                         "https://fedora.info/2018/06/25/spec/#acl-representation", ps);
@@ -156,7 +156,7 @@ public class WebACRepresentation extends AbstractAuthzTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void accessDenied(final String uri) {
-        final TestInfo info = setupTest("5.2-E", "accessDenied",
+        final TestInfo info = setupTest("5.2-E",
                 "If none of the authorizations grant the requested access then the request must be denied.",
                 "https://fedora.info/2018/06/25/spec/#acl-representation", ps);
 

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
@@ -57,7 +57,7 @@ public class Container extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void createLDPC(final String uri) {
-        final TestInfo info = setupTest("3.1.1-A", "createLDPC",
+        final TestInfo info = setupTest("3.1.1-A",
                                         "Implementations must support the creation and management of [LDP] Containers.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpc", ps);
         createBasicContainer(uri, info);
@@ -122,7 +122,7 @@ public class Container extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcMembershipTriples(final String uri) {
-        final TestInfo info = setupTest("3.1.1-C", "ldpcMembershipTriples",
+        final TestInfo info = setupTest("3.1.1-C",
                                         "LDP Containers must distinguish [membership] triples.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpc",
                                         ps);
@@ -221,7 +221,7 @@ public class Container extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcMinimalContainerTriples(final String uri) {
-        final TestInfo info = setupTest("3.1.1-D", "ldpcMinimalContainerTriples",
+        final TestInfo info = setupTest("3.1.1-D",
                                         "LDP Containers must distinguish [minimal-container] triples.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpc",
                                         ps);

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
@@ -111,7 +111,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void postCreateExternalBinaryContentCopy(final String uri) {
-        final TestInfo info = setupTest("3.9-A-1", "postCreateExternalBinaryContentCopy",
+        final TestInfo info = setupTest("3.9-A-1",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -132,7 +132,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void postCreateExternalFileUriBinaryCopy(final String uri) {
-        final TestInfo info = setupTest("3.9-A-1b", "postCreateExternalFileUriBinaryCopy",
+        final TestInfo info = setupTest("3.9-A-1b",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -153,7 +153,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void postCreateExternalBinaryContentRedirect(final String uri) {
-        final TestInfo info = setupTest("3.9-A-2", "postCreateExternalBinaryContentRedirect",
+        final TestInfo info = setupTest("3.9-A-2",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -173,7 +173,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void postCreateExternalFileUriBinaryRedirect(final String uri) {
-        final TestInfo info = setupTest("3.9-A-2b", "postCreateExternalFileUriBinaryRedirect",
+        final TestInfo info = setupTest("3.9-A-2b",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -193,7 +193,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void postCreateExternalBinaryContentProxy(final String uri) {
-        final TestInfo info = setupTest("3.9-A-3", "postCreateExternalBinaryContentProxy",
+        final TestInfo info = setupTest("3.9-A-3",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -213,7 +213,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void postCreateExternalFileUriBinaryProxy(final String uri) {
-        final TestInfo info = setupTest("3.9-A-3b", "postCreateExternalFileUriBinaryProxy",
+        final TestInfo info = setupTest("3.9-A-3b",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -233,7 +233,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putCreateExternalBinaryContentCopy(final String uri) {
-        final TestInfo info = setupTest("3.9-B-1", "putCreateExternalBinaryContentCopy",
+        final TestInfo info = setupTest("3.9-B-1",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -254,7 +254,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void putCreateExternalFileUriBinaryCopy(final String uri) {
-        final TestInfo info = setupTest("3.9-B-1b", "putCreateExternalFileUriBinaryCopy",
+        final TestInfo info = setupTest("3.9-B-1b",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -275,7 +275,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putCreateExternalBinaryContentRedirect(final String uri) {
-        final TestInfo info = setupTest("3.9-B-2", "putCreateExternalBinaryContentRedirect",
+        final TestInfo info = setupTest("3.9-B-2",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -296,7 +296,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void putCreateExternalFileUriBinaryRedirect(final String uri) {
-        final TestInfo info = setupTest("3.9-B-2b", "putCreateExternalFileUriBinaryRedirect",
+        final TestInfo info = setupTest("3.9-B-2b",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -317,7 +317,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putCreateExternalBinaryContentProxy(final String uri) {
-        final TestInfo info = setupTest("3.9-B-3", "putCreateExternalBinaryContentProxy",
+        final TestInfo info = setupTest("3.9-B-3",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -338,7 +338,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void putCreateExternalFileUriBinaryProxy(final String uri) {
-        final TestInfo info = setupTest("3.9-B-3b", "putCreateExternalFileUriBinaryProxy",
+        final TestInfo info = setupTest("3.9-B-3b",
                 "Fedora servers should support the creation of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -359,7 +359,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putUpdateExternalBinaryContentCopy(final String uri) {
-        final TestInfo info = setupTest("3.9-C-1", "putUpdateExternalBinaryContentCopy",
+        final TestInfo info = setupTest("3.9-C-1",
                 "Fedora servers should support the update of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -380,7 +380,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void putUpdateExternalFileUriBinaryCopy(final String uri) {
-        final TestInfo info = setupTest("3.9-C-1b", "putUpdateExternalFileUriBinaryCopy",
+        final TestInfo info = setupTest("3.9-C-1b",
                 "Fedora servers should support the update of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -401,7 +401,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putUpdateExternalBinaryContentRedirect(final String uri) {
-        final TestInfo info = setupTest("3.9-C-2", "putUpdateExternalBinaryContentRedirect",
+        final TestInfo info = setupTest("3.9-C-2",
                 "Fedora servers should support the update of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -422,7 +422,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void putUpdateExternalFileUriBinaryRedirect(final String uri) {
-        final TestInfo info = setupTest("3.9-C-2b", "putUpdateExternalFileUriBinaryRedirect",
+        final TestInfo info = setupTest("3.9-C-2b",
                 "Fedora servers should support the update of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -443,7 +443,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void putUpdateExternalBinaryContentProxy(final String uri) {
-        final TestInfo info = setupTest("3.9-C-3", "putUpdateExternalBinaryContentProxy",
+        final TestInfo info = setupTest("3.9-C-3",
                 "Fedora servers should support the update of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -464,7 +464,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void putUpdateExternalFileUriBinaryProxy(final String uri) {
-        final TestInfo info = setupTest("3.9-C-3b", "putUpdateExternalFileUriBinaryProxy",
+        final TestInfo info = setupTest("3.9-C-3b",
                 "Fedora servers should support the update of LDP-NRs with content external to the " +
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
@@ -485,7 +485,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void unsupportedExternalBinaryContentStatus(final String uri) {
-        final TestInfo info = setupTest("3.9-D-1", "unsupportedExternalBinaryContentStatus",
+        final TestInfo info = setupTest("3.9-D-1",
                 "Fedora servers that do not support the creation of LDP-NRs with content external must reject " +
                         "with a 4xx range status code",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
@@ -510,7 +510,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void unsupportedExternalBinaryContentConstraint(final String uri) {
-        final TestInfo info = setupTest("3.9-D-2", "unsupportedExternalBinaryContentConstraint",
+        final TestInfo info = setupTest("3.9-D-2",
                 "Fedora servers that do not support the creation of LDP-NRs with content external must describe " +
                         "this restriction in a resource indicated by a " +
                         "rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link in the Link response header.",
@@ -535,7 +535,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void externalBinaryContentHandlingAttribute(final String uri) {
-        final TestInfo info = setupTest("3.9-E-1", "externalBinaryContentHandlingAttribute",
+        final TestInfo info = setupTest("3.9-E-1",
                 "Fedora servers must use the handling attribute in the external content link to determine how to " +
                         "process the request. At least one of the following handling attributes must be supported: " +
                         "copy, redirect, and/or proxy.",
@@ -568,7 +568,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void externalBinaryContentHandlingStatus(final String uri) {
-        final TestInfo info = setupTest("3.9-E-2", "externalBinaryContentHandlingStatus",
+        final TestInfo info = setupTest("3.9-E-2",
                 "Fedora servers must reject with a 4xx range status code requests for which the handling attribute " +
                         "is not present or cannot be respected.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
@@ -590,7 +590,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void unsupportedBinaryContentHandlingAttribute(final String uri) {
-        final TestInfo info = setupTest("3.9-E-3", "unsupportedBinaryContentHandlingAttribute",
+        final TestInfo info = setupTest("3.9-E-3",
                 "In the case that the specified handling cannot be respected, the restrictions causing the request " +
                         "to fail must be described in a resource indicated by a " +
                         "rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link in the Link response header.",
@@ -613,7 +613,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void binaryContentMediaType(final String uri) {
-        final TestInfo info = setupTest("3.9-F-1", "binaryContentMediaType",
+        final TestInfo info = setupTest("3.9-F-1",
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
@@ -636,7 +636,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void binaryContentNoTypeExternalType(final String uri) {
-        final TestInfo info = setupTest("3.9-F-2", "binaryContentNoTypeExternalType",
+        final TestInfo info = setupTest("3.9-F-2",
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided. If there is no type attribute: " +
                         "Servers may use the media type obtained when accessing the external content via the " +
@@ -660,7 +660,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void binaryContentNoTypeDefault(final String uri) {
-        final TestInfo info = setupTest("3.9-F-3", "binaryContentNoTypeDefault",
+        final TestInfo info = setupTest("3.9-F-3",
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided. If there is no type attribute: " +
                         "Servers may use a default media type.",
@@ -684,7 +684,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void binaryContentNoTypeUnsupported(final String uri) {
-        final TestInfo info = setupTest("3.9-F-4", "binaryContentNoTypeUnsupported",
+        final TestInfo info = setupTest("3.9-F-4",
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided. If there is no type attribute: " +
                         "Servers may reject the request with a 4xx range status code.",
@@ -705,7 +705,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void binaryContentContentTypeAndType(final String uri) {
-        final TestInfo info = setupTest("3.9-F-5", "binaryContentContentTypeAndType",
+        final TestInfo info = setupTest("3.9-F-5",
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided. Any Content-Type header in the request should be " +
                         "ignored.",
@@ -731,7 +731,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void binaryContentContentTypeAndNoType(final String uri) {
-        final TestInfo info = setupTest("3.9-F-6", "binaryContentContentTypeAndNoType",
+        final TestInfo info = setupTest("3.9-F-6",
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided. Any Content-Type header in the request should be " +
                         "ignored.",
@@ -756,7 +756,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void binaryContentGuaranteeHeaders(final String uri) {
-        final TestInfo info = setupTest("3.9-G-1", "binaryContentGuaranteeHeaders",
+        final TestInfo info = setupTest("3.9-G-1",
                 "A Fedora server receiving requests that would create or update an LDP-NR with content external to " +
                         "the request entity must reject request if it cannot guarantee all of the response headers " +
                         "required by the LDP-NR interaction model in this specification.",
@@ -784,7 +784,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void binaryContentOptions(final String uri) {
-        final TestInfo info = setupTest("3.9.1", "binaryContentOptions",
+        final TestInfo info = setupTest("3.9.1",
                 "Fedora servers supporting external content MUST include \"Accept-External-Content-Handling\" " +
                         "header in response to \"OPTIONS\" request.",
                 "https://fedora.info/2018/06/25/spec/#external-content-options", ps);
@@ -801,7 +801,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void binaryContentRedirectWantDigest(final String uri) {
-        final TestInfo info = setupTest("3.9.3-A-1", "binaryContentRedirectWantDigest",
+        final TestInfo info = setupTest("3.9.3-A-1",
                 "Fedora servers supporting \"redirect\" external content types MUST correctly respond to the " +
                         "\"Want-Digest\" header.",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
@@ -825,7 +825,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void binaryContentProxyWantDigest(final String uri) {
-        final TestInfo info = setupTest("3.9.3-A-2", "binaryContentProxyWantDigest",
+        final TestInfo info = setupTest("3.9.3-A-2",
                 "Fedora servers supporting \"redirect\" external content types MUST correctly respond to the " +
                         "\"Want-Digest\" header.",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
@@ -849,7 +849,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void binaryContentRedirectStatusGet(final String uri) {
-        final TestInfo info = setupTest("3.9.3-B-1", "binaryContentRedirectStatusGet",
+        final TestInfo info = setupTest("3.9.3-B-1",
                 "A successful response to a GET request for external content with handling of redirect " +
                         "must have status code of either 302 (Found) or 307 (Temporary Redirect)",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
@@ -871,7 +871,7 @@ public class ExternalBinaryContent extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void binaryContentRedirectStatusHead(final String uri) {
-        final TestInfo info = setupTest("3.9.3-B-2", "binaryContentRedirectStatusHead",
+        final TestInfo info = setupTest("3.9.3-B-2",
                 "A successful response to a HEAD request for external content with handling of redirect " +
                         "must have status code of either 302 (Found) or 307 (Temporary Redirect)",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpDelete.java
@@ -53,7 +53,7 @@ public class HttpDelete extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void httpDeleteOptionsCheck(final String uri) {
-        final TestInfo info = setupTest("3.8.1-A", "httpDeleteOptionsCheck",
+        final TestInfo info = setupTest("3.8.1-A",
                                         "An implementation that cannot recurse should not advertise DELETE in " +
                                         "response to OPTIONS "
                                         + "requests for containers with contained resources.",
@@ -135,7 +135,7 @@ public class HttpDelete extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpDeleteStatusCheck(final String uri) {
-        final TestInfo info = setupTest("3.8.1-C", "httpDeleteStatusCheck",
+        final TestInfo info = setupTest("3.8.1-C",
                                         "An implementation must not return a 200 (OK) or 204 (No Content) response "
                                         + "unless the entire operation successfully completed.",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-delete-recursion",
@@ -212,7 +212,7 @@ public class HttpDelete extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpDeleteStatusCheckTwo(final String uri) {
-        final TestInfo info = setupTest("3.8.1-D", "httpDeleteStatusCheckTwo",
+        final TestInfo info = setupTest("3.8.1-D",
                                         "An implementation must not emit a message that implies the successful DELETE" +
                                         " of a resource until "
                                         + "the resource has been successfully removed.",

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpGet.java
@@ -62,7 +62,7 @@ public class HttpGet extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void additionalValuesForPreferHeader(final String uri) {
-        final TestInfo info = setupTest("3.2.1-A", "additionalValuesForPreferHeader",
+        final TestInfo info = setupTest("3.2.1-A",
                                         "In addition to the requirements of [LDP], an implementation ... " +
                                         "should support the value " +
                                         "http://fedora.info/definitions/fcrepo#PreferInboundReferences for the " +
@@ -97,7 +97,7 @@ public class HttpGet extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void additionalValuesForPreferHeaderContainedDescriptions(final String uri) {
-        final TestInfo info = setupTest("3.2.1-B", "additionalValuesForPreferHeaderContainedDescriptions",
+        final TestInfo info = setupTest("3.2.1-B",
                 "In addition to the requirements of [LDP], an implementation ... " +
                         "may support the value " +
                         "http://www.w3.org/ns/oa#PreferContainedDescriptions for the " +
@@ -130,7 +130,7 @@ public class HttpGet extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void responsePreferenceAppliedHeader(final String uri) {
-        final TestInfo info = setupTest("3.2.2-A", "responsePreferenceAppliedHeader",
+        final TestInfo info = setupTest("3.2.2-A",
                                         "Responses to GET requests that apply a Prefer request header to any LDP-RS " +
                                         "must "
                                         + "include the Preference-Applied"
@@ -153,7 +153,7 @@ public class HttpGet extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void responseDescribesHeader(final String uri) {
-        final TestInfo info = setupTest("3.2.2-B", "responseDescribesHeader",
+        final TestInfo info = setupTest("3.2.2-B",
                                         "When a GET request is made to an LDP-RS that describes an associated LDP-NR "
                                         + "(3.5 HTTP POST and [LDP]5.2.3.12),"
                                         +
@@ -190,7 +190,7 @@ public class HttpGet extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void respondWantDigest(final String uri) {
-        final TestInfo info = setupTest("3.2.3-A", "respondWantDigest",
+        final TestInfo info = setupTest("3.2.3-A",
                                         "Testing for supported digest "
                                         + "GET requests to any LDP-NR must correctly respond to the Want-Digest "
                                         + "header defined in [RFC3230]",
@@ -217,7 +217,7 @@ public class HttpGet extends AbstractTest {
     @Parameters({"param1"})
     public void respondWantDigestTwoSupported(final String uri) {
         final String checksum = "md5,sha";
-        final TestInfo info = setupTest("3.2.3-B", "respondWantDigestTwoSupported",
+        final TestInfo info = setupTest("3.2.3-B",
                                         "Testing for two supported digests with no weights"
                                         + " GET requests to any LDP-NR must correctly respond to the Want-Digest "
                                         + "header defined in [RFC3230]",
@@ -253,7 +253,7 @@ public class HttpGet extends AbstractTest {
     @Parameters({"param1"})
     public void respondWantDigestTwoSupportedQvalueNonZero(final String uri) {
         final String checksum = "md5;q=0.3,sha;q=1";
-        final TestInfo info = setupTest("3.2.3-C", "respondWantDigestTwoSupportedQvalueNonZero",
+        final TestInfo info = setupTest("3.2.3-C",
                                         "Testing for two supported digests with different weights"
                                         + "GET requests to any LDP-NR must correctly respond to the Want-Digest "
                                         + "header defined in [RFC3230]",
@@ -289,7 +289,7 @@ public class HttpGet extends AbstractTest {
     @Parameters({"param1"})
     public void respondWantDigestTwoSupportedQvalueZero(final String uri) {
         final String checksum = "md5;q=0.3,sha;q=0";
-        final TestInfo info = setupTest("3.2.3-D", "respondWantDigestTwoSupportedQvalueZero",
+        final TestInfo info = setupTest("3.2.3-D",
                                         "Testing for two supported digests with different weights q=0.3,q=0"
                                         + " GET requests to any LDP-NR must correctly respond to the Want-Digest"
                                         + " header defined in [RFC3230]",
@@ -315,7 +315,7 @@ public class HttpGet extends AbstractTest {
     public void respondWantDigestNonSupported(final String uri) {
         final String checksum = "md5,abc";
 
-        final TestInfo info = setupTest("3.2.3-E", "respondWantDigestNonSupported",
+        final TestInfo info = setupTest("3.2.3-E",
                                         "Testing for one supported digest and one unsupported digest."
                                         + "GET requests to any LDP-NR must correctly respond to the Want-Digest "
                                         + "header defined in [RFC3230]",

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpHead.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpHead.java
@@ -59,7 +59,7 @@ public class HttpHead extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpHeadResponseNoBody(final String uri) {
-        final TestInfo info = setupTest("3.3-A", "httpHeadResponseNoBody",
+        final TestInfo info = setupTest("3.3-A",
                                         "The HEAD method is identical to GET except that the server must not return a "
                                         + "message-body in the response, as "
                                         + "specified in [RFC7231] section 4.3.2.",
@@ -78,7 +78,7 @@ public class HttpHead extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpHeadResponseDigest(final String uri) {
-        final TestInfo info = setupTest("3.3-B", "httpHeadResponseDigest",
+        final TestInfo info = setupTest("3.3-B",
                                         "The server must send the same Digest header in the response as it"
                                         +
                                         " would have sent if the request had been a GET (or omit it if it would have " +
@@ -131,7 +131,7 @@ public class HttpHead extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void httpHeadResponseHeadersSameAsHttpGet(final String uri) {
-        final TestInfo info = setupTest("3.3-C", "httpHeadResponseHeadersSameAsHttpGet",
+        final TestInfo info = setupTest("3.3-C",
                                         "In other cases, The server should send the same headers in response to a " +
                                         "HEAD request "
                                         + "as it would have sent if the request had "

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpOptions.java
@@ -48,7 +48,7 @@ public class HttpOptions extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpOptionsSupport(final String uri) {
-        final TestInfo info = setupTest("3.4-A", "httpOptionsSupport",
+        final TestInfo info = setupTest("3.4-A",
                                         "Any LDPR must support OPTIONS per [LDP] 4.2.8. "
                                         + "4.2.8.1 LDP servers must support the HTTP OPTIONS method.",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-options",
@@ -64,7 +64,7 @@ public class HttpOptions extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpOptionsSupportAllow(final String uri) {
-        final TestInfo info = setupTest("3.4-B", "httpOptionsSupportAllow",
+        final TestInfo info = setupTest("3.4-B",
                                         "Any LDPR must support OPTIONS per [LDP] 4.2.8. "
                                         + "LDP servers must indicate their support for HTTP Methods by responding to a"
                                         +

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPatch.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPatch.java
@@ -79,7 +79,7 @@ public class HttpPatch extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void supportPatch(final String uri) {
-        final TestInfo info = setupTest("3.7-A", "supportPatch",
+        final TestInfo info = setupTest("3.7-A",
                                         "Any LDP-RS must support PATCH ([LDP] 4.2.7 may becomes must). " +
                                         "[sparql11-update] must be an accepted "
                                         + "content-type for PATCH.",
@@ -99,7 +99,7 @@ public class HttpPatch extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpPatchContentTypeSupport(final String uri) {
-        final TestInfo info = setupTest("3.7-B", "ldpPatchContentTypeSupport",
+        final TestInfo info = setupTest("3.7-B",
                                         "Other content-types (e.g. [ldpatch]) may be available.",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-patch", ps);
         final Response resource = createBasicContainer(uri, info);
@@ -116,7 +116,7 @@ public class HttpPatch extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void serverManagedPropertiesModification(final String uri) {
-        final TestInfo info = setupTest("3.7-C", "serverManagedPropertiesModification",
+        final TestInfo info = setupTest("3.7-C",
                                         "If an otherwise valid HTTP PATCH request is received that attempts to modify "
                                         + "statements to a resource that a server disallows (not ignores per [LDP] "
                                         + "4.2.4.1), the server must fail the request by responding with a 4xx range"
@@ -138,7 +138,7 @@ public class HttpPatch extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void statementNotPersistedResponseBody(final String uri) {
-        final TestInfo info = setupTest("3.7-D", "statementNotPersistedResponseBody",
+        final TestInfo info = setupTest("3.7-D",
                                         "The server must provide a corresponding response body containing information"
                                         + " about which statements could not be persisted."
                                         + " ([LDP] 4.2.4.4 should becomes must).",
@@ -160,7 +160,7 @@ public class HttpPatch extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void statementNotPersistedConstrainedBy(final String uri) {
-        final TestInfo info = setupTest("3.7-E", "statementNotPersistedConstrainedBy",
+        final TestInfo info = setupTest("3.7-E",
                                         "In that response, the restrictions causing such a request to fail must be"
                                         + " described in a resource indicated by a Link: "
                                         + "rel=\"http://www.w3.org/ns/ldp#constrainedBy\" "
@@ -183,7 +183,7 @@ public class HttpPatch extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void successfulPatchStatusCode(final String uri) {
-        final TestInfo info = setupTest("3.7-F", "successfulPatchStatusCode",
+        final TestInfo info = setupTest("3.7-F",
                                         "A successful PATCH request must respond with a 2xx status code; the "
                                         + "specific code in the 2xx range may vary according to the response "
                                         + "body or request state.",
@@ -219,7 +219,7 @@ public class HttpPatch extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void disallowPatchContainmentTriples(final String uri) {
-        final TestInfo info = setupTest("3.7.1", "disallowPatchContainmentTriples",
+        final TestInfo info = setupTest("3.7.1",
                                         "The server should not allow HTTP PATCH to update an LDPC’s containment " +
                                         "triples; if"
                                         + " the server receives such a request, it should respond with a"
@@ -244,7 +244,7 @@ public class HttpPatch extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void disallowChangeResourceType(final String uri) {
-        final TestInfo info = setupTest("3.7.2", "disallowChangeResourceType",
+        final TestInfo info = setupTest("3.7.2",
                                         "The server must disallow a PATCH request that would change the LDP"
                                         + " interaction model of a resource to a type that is not a subtype"
                                         + " of the current resource type. That request must be rejected"

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPost.java
@@ -53,7 +53,7 @@ public class HttpPost extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPost(final String uri) {
-        final TestInfo info = setupTest("3.5-A", "httpPost",
+        final TestInfo info = setupTest("3.5-A",
                                         "Any LDPC (except Version Containers (LDPCv)) must support POST ([LDP] 4.2.3 " +
                                         "/ 5.2.3). ",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-post", ps);
@@ -69,7 +69,7 @@ public class HttpPost extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void constrainedByResponseHeader(final String uri) {
-        final TestInfo info = setupTest("3.5-B", "constrainedByResponseHeader",
+        final TestInfo info = setupTest("3.5-B",
                                         "The default interaction model that will be assigned when there is no " +
                                         "explicit Link "
                                         + "header in the request must be recorded in the constraints"
@@ -89,7 +89,7 @@ public class HttpPost extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void postNonRDFSource(final String uri) {
-        final TestInfo info = setupTest("3.5.1-A", "postNonRDFSource",
+        final TestInfo info = setupTest("3.5.1-A",
                                         "Any LDPC must support creation of LDP-NRs on POST ([LDP] 5.2.3.3 may becomes" +
                                         " must).",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-post", ps);
@@ -107,7 +107,7 @@ public class HttpPost extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void postResourceAndCheckAssociatedResource(final String uri) {
-        final TestInfo info = setupTest("3.5.1-B", "postResourceAndCheckAssociatedResource",
+        final TestInfo info = setupTest("3.5.1-B",
                                         "On creation of an LDP-NR, an implementation must create an associated LDP-RS" +
                                         " describing"
                                         + " that LDP-NR ([LDP] 5.2.3.12 may becomes must).",
@@ -128,7 +128,7 @@ public class HttpPost extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void postDigestResponseHeaderAuthentication(final String uri) {
-        final TestInfo info = setupTest("3.5.1-C", "postDigestResponseHeaderAuthentication",
+        final TestInfo info = setupTest("3.5.1-C",
                                         "An HTTP POST request that would create an LDP-NR and includes a Digest " +
                                         "header (as described"
                                         +
@@ -154,7 +154,7 @@ public class HttpPost extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void postDigestResponseHeaderVerification(final String uri) {
-        final TestInfo info = setupTest("3.5.1-D", "postDigestResponseHeaderVerification",
+        final TestInfo info = setupTest("3.5.1-D",
                                         "An HTTP POST request that includes an unsupported Digest type (as described " +
                                         "in [RFC3230]), "
                                         + "should be rejected with a 400 Bad Request response.",

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
@@ -58,7 +58,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void httpPut(final String uri) {
-        final TestInfo info = setupTest("3.6-B", "httpPut",
+        final TestInfo info = setupTest("3.6-B",
                                         "When accepting a PUT request against an existant resource, an HTTP Link: " +
                                         "rel=\"type\" header "
                                         +
@@ -91,7 +91,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPutpdateTriples(final String uri) {
-        final TestInfo info = setupTest("3.6.1-A", "httpPutpdateTriples",
+        final TestInfo info = setupTest("3.6.1-A",
                                         "Any LDP-RS must support PUT to update statements that are not server-managed" +
                                         " triples (as defined "
                                         + "in [LDP] 2). [LDP] 4.2.4.1 and 4.2.4.3 remain in effect.",
@@ -136,7 +136,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPutUpdateDisallowedTriples(final String uri) {
-        final TestInfo info = setupTest("3.6.1-B", "httpPutUpdateDisallowedTriples",
+        final TestInfo info = setupTest("3.6.1-B",
                                         "If an otherwise valid HTTP PUT request is received that attempts to modify " +
                                         "resource "
                                         + "statements that a server"
@@ -185,7 +185,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPutUpdateDisallowedTriplesResponse(final String uri) {
-        final TestInfo info = setupTest("3.6.1-C", "httpPutUpdateDisallowedTriplesResponse",
+        final TestInfo info = setupTest("3.6.1-C",
                                         "The server must provide a corresponding response body containing information "
                                         + "about which statements could"
                                         + " not be persisted. ([LDP] 4.2.4.4 should becomes must).",
@@ -231,7 +231,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPutUpdateDisallowedTriplesConstrainedByHeader(final String uri) {
-        final TestInfo info = setupTest("3.6.1-D", "httpPutUpdateDisallowedTriplesConstrainedByHeader",
+        final TestInfo info = setupTest("3.6.1-D",
                                         "In that response, the restrictions causing such a request to fail must be "
                                         + "described in a resource indicated"
                                         +
@@ -279,7 +279,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void httpPutNR(final String uri) {
-        final TestInfo info = setupTest("3.6.2-A", "httpPutNR",
+        final TestInfo info = setupTest("3.6.2-A",
                                         "Any LDP-NR must support PUT to replace the binary content of that resource.",
                                         "https://fcrepo.github.io/fcrepo-specification/#http-put-ldpnr", ps);
         final Headers headers = new Headers(
@@ -316,7 +316,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void nonRDFSourcePutDigestResponseHeaderAuthentication(final String uri) {
-        final TestInfo info = setupTest("3.6.2-B", "nonRDFSourcePutDigestResponseHeaderAuthentication",
+        final TestInfo info = setupTest("3.6.2-B",
                                         "An HTTP PUT request that includes a Digest header (as described in " +
                                         "[RFC3230]) for which any "
                                         +
@@ -347,7 +347,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void nonRDFSourcePutDigestResponseHeaderVerification(final String uri) {
-        final TestInfo info = setupTest("3.6.2-C", "nonRDFSourcePutDigestResponseHeaderVerification",
+        final TestInfo info = setupTest("3.6.2-C",
                                         "An HTTP PUT request that includes an unsupported Digest type (as described " +
                                         "in [RFC3230]), should"
                                         + " be rejected with a 400 (Bad Request) response.",
@@ -375,7 +375,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void putCreateRDFSource(final String uri) {
-        final TestInfo info = setupTest("3.6.3-A", "putCreateRDFSource",
+        final TestInfo info = setupTest("3.6.3-A",
                 "Implementations may accept HTTP PUT to create resources",
                 "https://fcrepo.github.io/fcrepo-specification/#http-put-create", ps);
 
@@ -394,7 +394,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void putCreateNonRDFSource(final String uri) {
-        final TestInfo info = setupTest("3.6.3-B", "putCreateNonRDFSource",
+        final TestInfo info = setupTest("3.6.3-B",
                 "Implementations may accept HTTP PUT to create non-RDF resources",
                 "https://fcrepo.github.io/fcrepo-specification/#http-put-create", ps);
 
@@ -416,7 +416,7 @@ public class HttpPut extends AbstractTest {
     @Test(groups = { "MUST" })
     @Parameters({ "param1" })
     public void putNonRDFSourceCreateLDPRS(final String uri) {
-        final TestInfo info = setupTest("3.6.3-C", "putNonRDFSourceCreateLDPRS",
+        final TestInfo info = setupTest("3.6.3-C",
                 "On creation of an LDP-NR with HTTP PUT, implementations MUST create " +
                         "an associated LDP-RS describing that LDP-NR in the same way that it " +
                         "would when 3.5.1 Creating LDP-NRs with HTTP POST",

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Ldpnr.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Ldpnr.java
@@ -54,7 +54,7 @@ public class Ldpnr extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpnrCreationLinkType(final String uri) {
-        final TestInfo info = setupTest("3.1.2-A", "ldpnrCreationLinkType",
+        final TestInfo info = setupTest("3.1.2-A",
                                         "If, in a successful resource creation request, a Link: rel=\"type\" request " +
                                         "header specifies"
                                         +
@@ -115,7 +115,7 @@ public class Ldpnr extends AbstractTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpnrCreationWrongLinkType(final String uri) {
-        final TestInfo info = setupTest("3.1.2-B", "ldpnrCreationWrongLinkType",
+        final TestInfo info = setupTest("3.1.2-B",
                                         "If, in a successful resource creation request, a Link: rel=\"type\" request " +
                                         "header specifies"
                                         +

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpDelete.java
@@ -51,7 +51,7 @@ public class LdpcvHttpDelete extends AbstractVersioningTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMaySupportDelete(final String uri) {
-        final TestInfo info = setupTest("4.3.6-A", "ldpcvMaySupportDelete",
+        final TestInfo info = setupTest("4.3.6-A",
                                         "An implementation MAY support DELETION of LDPCvs.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-delete",
                                         ps);
@@ -73,7 +73,7 @@ public class LdpcvHttpDelete extends AbstractVersioningTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpcvThatAdvertisesDeleteShouldRemoveContainerAndMementos(final String uri) {
-        final TestInfo info = setupTest("4.3.6-B", "ldpcvThatAdvertisesDeleteShouldRemoveContainerAndMementos",
+        final TestInfo info = setupTest("4.3.6-B",
                                         "An implementation that does support DELETE should do so by both " +
                                         "removing the LDPCv and removing the versioning interaction model from the " +
                                         "original LDPRv.",

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpGet.java
@@ -53,7 +53,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustSupportGet(final String uri) {
-        final TestInfo info = setupTest("4.3.1-A", "ldpcvMustSupportGet",
+        final TestInfo info = setupTest("4.3.1-A",
                                         "LDPCv must support GET, as is the case for any LDPR",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
                                         ps);
@@ -71,7 +71,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustHaveTimeMapLinkHeader(final String uri) {
-        final TestInfo info = setupTest("4.3.1-B", "ldpcvMustHaveTimeMapLinkHeader",
+        final TestInfo info = setupTest("4.3.1-B",
                                         "LDPCv contain TimeMap type link header.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
                                         ps);
@@ -95,7 +95,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustRespondToGetWithApplicationLinkAcceptHeader(final String uri) {
-        final TestInfo info = setupTest("4.3.1-C", "ldpcvMustRespondToGetWithApplicationLinkAcceptHeader",
+        final TestInfo info = setupTest("4.3.1-C",
                                         "An LDPCv must respond to GET Accept: application/link-format as " +
                                         "indicated in [ RFC7089 ] section 5 and specified in [ RFC6690 ] section 7.3.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
@@ -114,7 +114,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void lpcvMustIncludeAllowHeader(final String uri) {
-        final TestInfo info = setupTest("4.3.1-D", "lpcvMustIncludeAllowHeader",
+        final TestInfo info = setupTest("4.3.1-D",
                                         "LDPCv resources must include the Allow header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
                                         ps);
@@ -135,7 +135,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustIncludeAcceptPostIfPostAllowed(final String uri) {
-        final TestInfo info = setupTest("4.3.1-E", "ldpcvMustIncludeAcceptPostIfPostAllowed",
+        final TestInfo info = setupTest("4.3.1-E",
                                         "If an LDPCv supports POST, then it must include the Accept-Post header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
                                         ps);
@@ -156,7 +156,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustIncludeAcceptPatchIfPatchAllowed(final String uri) {
-        final TestInfo info = setupTest("4.3.1-F", "ldpcvMustIncludeAcceptPatchIfPatchAllowed",
+        final TestInfo info = setupTest("4.3.1-F",
                                         "If an LDPCv supports PATCH, then it must include the Accept-Patch header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",
                                         ps);
@@ -179,7 +179,7 @@ public class LdpcvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustHaveContainerLinkHeader(final String uri) {
-        final TestInfo info = setupTest("4.3.1-G", "ldpcvMustHaveContainerLinkHeader",
+        final TestInfo info = setupTest("4.3.1-G",
                                         "An LDPCv, being a container must have a \"Link: <http://www" +
                                         ".w3.org/ns/ldp#Container>;rel=\"type\"\"",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-get",

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpOptions.java
@@ -49,7 +49,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustSupportOptions(final String uri) {
-        final TestInfo info = setupTest("4.3.2-A", "ldpcvMustSupportOptions",
+        final TestInfo info = setupTest("4.3.2-A",
                                         "LDPCv (version containers) MUST support OPTIONS.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
                                         ps);
@@ -74,7 +74,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvOptionsMustAllowHeadGetOptions(final String uri) {
-        final TestInfo info = setupTest("4.3.2-B", "ldpcvOptionsMustAllowHeadGetOptions",
+        final TestInfo info = setupTest("4.3.2-B",
                                         "LDPCv's response to an OPTIONS request MUST include \"Allow: GET, " +
                                         "HEAD, OPTIONS\" per LDP",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
@@ -103,7 +103,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMaySupportDeleteOption(final String uri) {
-        final TestInfo info = setupTest("4.3.2-C", "ldpcvMaySupportDeleteOption",
+        final TestInfo info = setupTest("4.3.2-C",
                                         "LDPCv (version containers) MAY support DELETE.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
                                         ps);
@@ -128,7 +128,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMaySupportPatch(final String uri) {
-        final TestInfo info = setupTest("4.3.2-D", "ldpcvMaySupportPatch",
+        final TestInfo info = setupTest("4.3.2-D",
                                         "LDPCv (version containers) MAY support PATCH.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
                                         ps);
@@ -153,7 +153,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMaySupportPost(final String uri) {
-        final TestInfo info = setupTest("4.3.2-E", "ldpcvMaySupportPost",
+        final TestInfo info = setupTest("4.3.2-E",
                                         "LDPCv (version containers) MAY support POST.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
                                         ps);
@@ -178,7 +178,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustReturnAcceptPostHeaderIfPostIsSupported(final String uri) {
-        final TestInfo info = setupTest("4.3.2-F", "ldpcvMustReturnAcceptPostHeaderIfPostIsSupported",
+        final TestInfo info = setupTest("4.3.2-F",
                                         "If an LDPCv supports POST, the response to an OPTIONS request " +
                                         " MUST include the \"Accept-Post\" header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",
@@ -209,7 +209,7 @@ public class LdpcvHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvMustReturnAcceptPatchHeaderIfPatchIsSupported(final String uri) {
-        final TestInfo info = setupTest("4.3.2-G", "ldpcvMustReturnAcceptPatchHeaderIfPatchIsSupported",
+        final TestInfo info = setupTest("4.3.2-G",
                                         "If an LDPCv supports PATCH, the response to an OPTIONS request " +
                                         " MUST include the \"Accept-Patch\" header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-options",

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
@@ -57,7 +57,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = { "MAY" })
     @Parameters({ "param1" })
     public void ldpcvMayDisallowPost(final String uri) {
-        final TestInfo info = setupTest("4.3", "ldpcvMayDisallowPost",
+        final TestInfo info = setupTest("4.3",
                 "Although an LDPCv is both a TimeMap and an LDPC, implementations MAY disallow POST requests.",
                 "https://fedora.info/2018/06/25/spec/#ldpcv-post",
                 ps);
@@ -78,7 +78,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpcvOfLdprsShouldSupportPostWithoutMementoDatetimeHeader(final String uri) {
-        final TestInfo info = setupTest("4.3.3.1-A", "ldpcvOfLdprsShouldSupportPostWithoutMementoDatetimeHeader",
+        final TestInfo info = setupTest("4.3.3.1-A",
                                         "If an LDPCv of an LDP-RS supports POST, a POST request that does not contain" +
                                         " a Memento-Datetime header should be understood to create a new LDPRm " +
                                         "contained by the LDPCv, reflecting the state of the LDPRv at the time of " +
@@ -119,7 +119,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void ldpcvOfLdpnrsShouldSupportPostWithoutMementoDatetimeHeader(final String uri) {
-        final TestInfo info = setupTest("4.3.3.1-B", "ldpcvOfLdpnrsShouldSupportPostWithoutMementoDatetimeHeader",
+        final TestInfo info = setupTest("4.3.3.1-B",
                                         "If an LDPCv of an LDP-NR supports POST, a POST request that does not contain" +
                                         " a Memento-Datetime header should be understood to create a new LDPRm " +
                                         "contained by the LDPCv, reflecting the state of the LDPRv at the time of " +
@@ -158,7 +158,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void postToldpcvOfLdprsWithoutMementoDatetimeMustIgnoreBody(final String uri) {
-        final TestInfo info = setupTest("4.3.3.1-C", "postToldpcvOfLdprsWithoutMementoDatetimeMustIgnoreBody",
+        final TestInfo info = setupTest("4.3.3.1-C",
                                         "If an LDPCv of an LDP-RS supports POST, a POST request that does not contain" +
                                         " a " +
                                         "Memento-Datetime header MUST ignore any request body.",
@@ -197,7 +197,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void postToldpcvOfLdpnrWithoutMementoDatetimeMustIgnoreBody(final String uri) {
-        final TestInfo info = setupTest("4.3.3.1-D", "postToldpcvOfLdpnrWithoutMementoDatetimeMustIgnoreBody",
+        final TestInfo info = setupTest("4.3.3.1-D",
                                         "If an LDPCv of an LDP-NR supports POST, a POST request that does not contain" +
                                         " a " +
                                         "Memento-Datetime header MUST ignore any request body.",
@@ -234,7 +234,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void postToldpcvOfLdprWithMementoDatetimeShouldCreateNewResource(final String uri) {
-        final TestInfo info = setupTest("4.3.3.1-E", "postToldpcvOfLdprWithMementoDatetimeShouldCreateNewResource",
+        final TestInfo info = setupTest("4.3.3.1-E",
                                         "If an LDPCv supports POST, a POST with a Memento-Datetime header " +
                                         "should be understood to create a new LDPRm contained by the LDPCv, with the " +
                                         "state given in the request body.",
@@ -268,7 +268,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void mementoDatetimeHeaderShouldMatchThatUsedWhenMementoCreated(final String uri) {
-        final TestInfo info = setupTest("4.3.3.1-F", "mementoDatetimeHeaderShouldMatchThatUsedWhenMementoCreated",
+        final TestInfo info = setupTest("4.3.3.1-F",
                                         " If an LDPCv supports POST, a POST with a Memento-Datetime header " +
                                         "should be understood to create a new LDPRm contained by the LDPCv, with the " +
                                         "datetime given in the Memento-Datetime request header.",
@@ -301,7 +301,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpcvDoesNotSupportPost(final String uri) {
-        final TestInfo info = setupTest("4.3.3.2", "ldpcvDoesNotSupportPost",
+        final TestInfo info = setupTest("4.3.3.2",
                                         "If an implementation does not support one or both of POST cases " +
                                         "above, it must respond to such requests with a 4xx range status code and a " +
                                         "link to an appropriate constraints document",
@@ -341,7 +341,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMayDisallowPut(final String uri) {
-        final TestInfo info = setupTest("4.3.4", "ldpcvMayDisallowPut",
+        final TestInfo info = setupTest("4.3.4",
                                         "Implementations MAY disallow PUT.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-put",
                                         ps);
@@ -365,7 +365,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldpcvMayDisallowPatch(final String uri) {
-        final TestInfo info = setupTest("4.3.5", "ldpcvMayDisallowPatch",
+        final TestInfo info = setupTest("4.3.5",
                                         "Implementations MAY disallow PATCH",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldpcv-patch",
                                         ps);

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpDelete.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpDelete.java
@@ -55,7 +55,7 @@ public class LdprmHttpDelete extends AbstractVersioningTest {
     @Test(groups = { "MUST" })
     @Parameters({"param1"})
     public void ldprmMustSupportDeleteIfAdvertised(final String uri) {
-        final TestInfo info = setupTest("4.2.6", "ldprmMustSupportDeleteIfAdvertised",
+        final TestInfo info = setupTest("4.2.6",
                                         "LDPRm resources must support DELETE if DELETE is advertised in OPTIONS",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-delete",
                                         ps);

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpGet.java
@@ -57,7 +57,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     @Test(groups = { "MUST" })
     @Parameters({"param1"})
     public void ldprmMustSupportGet(final String uri) {
-        final TestInfo info = setupTest("4.2.1-A", "ldprmMustSupportGet",
+        final TestInfo info = setupTest("4.2.1-A",
                                         "LDPR mementos must support GET",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
                                         ps);
@@ -79,7 +79,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     @Test(groups = { "MUST" })
     @Parameters({"param1"})
     public void ldpnrmMustSupportGet(final String uri) {
-        final TestInfo info = setupTest("4.2.1-B", "ldpnrmMustSupportGet",
+        final TestInfo info = setupTest("4.2.1-B",
                                         "LDP-NR mementos must support GET",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
                                         ps);
@@ -102,7 +102,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     @Test(groups = { "MUST" })
     @Parameters({"param1"})
     public void ldprmMustHaveCorrectTimeGate(final String uri) {
-        final TestInfo info = setupTest("4.2.1-C", "ldprmMustHaveCorrectTimeGate",
+        final TestInfo info = setupTest("4.2.1-C",
                 "TimeGate for an  LDP-RS memento is the original versioned LDP-RS",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
                                         ps);
@@ -130,7 +130,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     @Test(groups = { "MUST" })
     @Parameters({"param1"})
     public void ldpnrmMustHaveCorrectTimeGate(final String uri) {
-        final TestInfo info = setupTest("4.2.1-D", "ldpnrmMustHaveCorrectTimeGate",
+        final TestInfo info = setupTest("4.2.1-D",
                                         "TimeGate  for an  LDP-NR memento  is the original versioned LDP-NR",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
                                         ps);
@@ -158,7 +158,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     @Test(groups = { "MUST" })
     @Parameters({"param1"})
     public void ldprmMustHaveMementoLinkHeader(final String uri) {
-        final TestInfo info = setupTest("4.2.1-E", "ldprmMustHaveMementoLinkHeader",
+        final TestInfo info = setupTest("4.2.1-E",
                                         "Any response to a GET request on an LDP-RS Memento must include a " +
                                         "<http://mementoweb.org/ns#Memento>; rel=\"type\" link in the Link header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",
@@ -182,7 +182,7 @@ public class LdprmHttpGet extends AbstractVersioningTest {
     @Test(groups = { "MUST" })
     @Parameters({"param1"})
     public void ldpnrmMustHaveMementoLinkHeader(final String uri) {
-        final TestInfo info = setupTest("4.2.1-F", "ldpnrmMustHaveMementoLinkHeader",
+        final TestInfo info = setupTest("4.2.1-F",
                                         "Any response to a GET request on an LDP-NR Memento must include a " +
                                         "<http://mementoweb.org/ns#Memento>; rel=\"type\" link in the Link header",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-get",

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpOptions.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprmHttpOptions.java
@@ -50,7 +50,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldprmMustSupportOptions(final String uri) {
-        final TestInfo info = setupTest("4.2.2-A", "ldprmMustSupportOptions",
+        final TestInfo info = setupTest("4.2.2-A",
                                         "LDPRm resources must support OPTIONS",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-options",
                                         ps);
@@ -76,7 +76,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldprmOptionsMustSupportGetHeadAndOptions(final String uri) {
-        final TestInfo info = setupTest("4.2.2-B", "ldprmOptionsMustSupportGetHeadAndOptions",
+        final TestInfo info = setupTest("4.2.2-B",
                                         "A response to an OPTIONS request must include Allow: GET, HEAD, OPTIONS",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-options",
                                         ps);
@@ -98,7 +98,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MAY"})
     @Parameters({"param1"})
     public void ldprmOptionsMaySupportDelete(final String uri) {
-        final TestInfo info = setupTest("4.2.2-C", "ldprmOptionsMaySupportDelete",
+        final TestInfo info = setupTest("4.2.2-C",
                                         "A response to an OPTIONS request may include Allow: DELETE",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-options",
                                         ps);
@@ -119,7 +119,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldprmMustNotSupportPost(final String uri) {
-        final TestInfo info = setupTest("4.2.3", "ldprmMustNotSupportPost",
+        final TestInfo info = setupTest("4.2.3",
                                         "An LDPRm must not support POST",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-post",
                                         ps);
@@ -141,7 +141,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldprmMustNotSupportPut(final String uri) {
-        final TestInfo info = setupTest("4.2.4", "ldprmMustNotSupportPut",
+        final TestInfo info = setupTest("4.2.4",
                                         "An LDPRm must not support PUT",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-put",
                                         ps);
@@ -165,7 +165,7 @@ public class LdprmHttpOptions extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldprmMustNotSupportPatch(final String uri) {
-        final TestInfo info = setupTest("4.2.5", "ldprmMustNotSupportPatch",
+        final TestInfo info = setupTest("4.2.5",
                                         "An LDPRm must not support PATCH",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprm-patch",
                                         ps);

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
@@ -59,7 +59,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"SHOULD"})
     @Parameters({"param1"})
     public void shouldReturn406WhenNoLdprm(final String uri) {
-        final TestInfo info = setupTest("4.1.1-A-1", "shouldReturn406WhenNoLdprm",
+        final TestInfo info = setupTest("4.1.1-A-1",
                                         "If no LDPRm is appropriate to the Accept-Datetime value, " +
                                         "implementations should return a 406 (Unacceptable).",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-get",
@@ -95,7 +95,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void shouldReturn302WhenLdprmFromTimeGate(final String uri) {
-        final TestInfo info = setupTest("4.1.1-A-2", "shouldReturn302WhenLdprmFromTimeGate",
+        final TestInfo info = setupTest("4.1.1-A-2",
                                         "The Accept-Datetime header is used to request a past state, " +
                                         "exactly as per [RFC7089] section 2.1.1. A successful response must be a 302 " +
                                         "(Found) redirect to the appropriate LDPRm.",
@@ -141,7 +141,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpvGetMustReturnHeaderOriginalTypeLink(final String uri) {
-        final TestInfo info = setupTest("4.1.1-B", "ldpvGetMustReturnHeaderOriginalTypeLink",
+        final TestInfo info = setupTest("4.1.1-B",
                                         "The response to a GET request on an LDPRv must return " +
                                         " a rel=\"timegate\" Link header referencing itself ",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-get",
@@ -162,7 +162,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpvGetMustReturnHeaderTimeGateTypeLink(final String uri) {
-        final TestInfo info = setupTest("4.1.1-C", "ldpvGetMustReturnHeaderTimeGateTypeLink",
+        final TestInfo info = setupTest("4.1.1-C",
                                         "The response to a GET request on an LDPRv must return " +
                                         " a rel=\"timegate\" Link header referencing itself",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-get",
@@ -183,7 +183,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpvGetMustReturnOriginalResourceLink(final String uri) {
-        final TestInfo info = setupTest("4.1.1-D", "ldpvGetMustReturnOriginalResourceLink",
+        final TestInfo info = setupTest("4.1.1-D",
                                         "The response to a GET request on an LDPRv must return a " +
                                         "<http://mementoweb.org/ns#OriginalResource>; rel=\"type\" link in the " +
                                         "Link header.",
@@ -204,7 +204,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpvGetMustReturnTimeGateTypeLink(final String uri) {
-        final TestInfo info = setupTest("4.1.1-E", "ldpvGetMustReturnTimeGateTypeLink",
+        final TestInfo info = setupTest("4.1.1-E",
                                         "The response to a GET request on an LDPRv must return a " +
                                         "<http://mementoweb.org/ns#OriginalResource>; rel=\"type\" link in the " +
                                         "Link header.",
@@ -225,7 +225,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpvGetMustReturnTimeMapLink(final String uri) {
-        final TestInfo info = setupTest("4.1.1-F", "ldpvGetMustReturnTimeMapLink",
+        final TestInfo info = setupTest("4.1.1-F",
                                         "The response to a GET request on an LDPRv must return At least one " +
                                         "rel=\"timemap\" link in the Link header referencing an associated LDPCv",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-get",
@@ -246,7 +246,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpvGetMustReturnVaryHeader(final String uri) {
-        final TestInfo info = setupTest("4.1.1-G", "ldpvGetMustReturnVaryHeader",
+        final TestInfo info = setupTest("4.1.1-G",
                                         "The response to a GET request on an LDPRv must return " +
                                         "a Vary: Accept-Datetime header, exactly as per [RFC7089] section 2.1.2.",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-get",

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpPut.java
@@ -54,7 +54,7 @@ public class LdprvHttpPut extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldprvMustSupportPUT(final String uri) {
-        final TestInfo info = setupTest("4.1.2-A", "ldprvMustSupportPUT",
+        final TestInfo info = setupTest("4.1.2-A",
                                         "Must support PUT for creating new LDPRv",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-put",
                                         ps);
@@ -76,7 +76,7 @@ public class LdprvHttpPut extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldprvMustSupportPUTForExistingResources(final String uri) {
-        final TestInfo info = setupTest("4.1.2-B", "ldprvMustSupportPUTForExistingResources",
+        final TestInfo info = setupTest("4.1.2-B",
                                         "Must support PUT for updating existing LDPRvs",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-put",
                                         ps);
@@ -115,7 +115,7 @@ public class LdprvHttpPut extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpnrvMustSupportPUT(final String uri) {
-        final TestInfo info = setupTest("4.1.2-C", "ldpnrvMustSupportPUT",
+        final TestInfo info = setupTest("4.1.2-C",
                                         "Must support PUT for creating new LDPNRv",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-put",
                                         ps);
@@ -140,7 +140,7 @@ public class LdprvHttpPut extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void ldpnrvMustSupportPUTForExistingResources(final String uri) {
-        final TestInfo info = setupTest("4.1.2-D", "ldpnrvMustSupportPUTForExistingResources",
+        final TestInfo info = setupTest("4.1.2-D",
                                         "Must support PUT for updating existing  LDPNRvs",
                                         "https://fcrepo.github.io/fcrepo-specification/#ldprv-put",
                                         ps);

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/ResourceVersioning.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/ResourceVersioning.java
@@ -51,7 +51,7 @@ public class ResourceVersioning extends AbstractVersioningTest {
     @Test(groups = {"MUST"})
     @Parameters({"param1"})
     public void postLdprWithType(final String uri) {
-        final TestInfo info = setupTest("4.0-A", "postLdprWithType",
+        final TestInfo info = setupTest("4.0-A",
                                         "When an LDPR is created with a rel=\"type\" link in the Link " +
                                         "header specifying type http://mementoweb.org/ns#OriginalResource " +
                                         "to indicate versioning, it MUST be created as an LDPRv and a version " +
@@ -78,7 +78,7 @@ public class ResourceVersioning extends AbstractVersioningTest {
     @Test(groups = { "MUST" })
     @Parameters({ "param1" })
     public void putLdprWithType(final String uri) {
-        final TestInfo info = setupTest("4.0-B", "putLdprWithType",
+        final TestInfo info = setupTest("4.0-B",
                 "When an LDPR is created with a rel=\"type\" link in the Link " +
                         "header specifying type http://mementoweb.org/ns#OriginalResource " +
                         "to indicate versioning, it MUST be created as an LDPRv and a version " +


### PR DESCRIPTION
Optionally make test setup a little shorter/easier to maintain by automating the title (test method name) parameter