### PR TITLE
5.7.1 acl:Append on LDP-RS tests

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -414,17 +414,19 @@ public class AbstractTest {
 
     protected Response doPatchUnverified(final String uri, final Headers headers, final String body,
                                          final boolean admin) {
-        return createRequest(admin).config(
-            RestAssured.config().encoderConfig(
-                new EncoderConfig().encodeContentTypeAs(APPLICATION_SPARQL_UPDATE, ContentType.TEXT)))
-                                   .headers(headers).body(body).when().patch(uri);
+        final RequestSpecification req = createRequest(admin).config(RestAssured.config().encoderConfig(
+                new EncoderConfig().encodeContentTypeAs(APPLICATION_SPARQL_UPDATE, ContentType.TEXT)));
+        if (headers != null) {
+            req.headers(headers);
+        }
+        if (body != null) {
+            req.body(body);
+        }
+        return req.when().patch(uri);
     }
 
     protected Response doPatchUnverified(final String uri) {
-        return createRequest().config(
-            RestAssured.config().encoderConfig(
-                new EncoderConfig().encodeContentTypeAs(APPLICATION_SPARQL_UPDATE, ContentType.TEXT)))
-                              .when().patch(uri);
+        return doPatchUnverified(uri, null, null, true);
     }
 
     protected String getLocation(final Response response) {

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -568,13 +568,6 @@ public class WebACModes extends AbstractAuthzTest {
         // verify failure.
         putResponse.then().statusCode(403);
 
-        // perform PUT to child resource as non-admin succeeds.
-        final Response putChildResponse =
-                doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
-                        "test", false);
-        // verify successful
-        putChildResponse.then().statusCode(201);
-
         // perform PATCH which also deletes.
         final Response patchDelete = doPatchUnverified(resourceUri, new Headers(new Header("Content-type",
                 "application/sparql-update")),

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -549,8 +549,7 @@ public class WebACModes extends AbstractAuthzTest {
     public void appendNotWriteLdpRsMust(final String uri) {
         final TestInfo info = setupTest("5.7.1-A", "appendNotWriteLdpRsMust",
                 "When a client has acl:Append but not acl:Write for an LDP-RS they MUST " +
-                        "not DELETE, not PATCH that deletes triples, not PUT on the resource, and " +
-                        "must be able to PUT a child resource",
+                        "not DELETE, not PATCH that deletes triples, not PUT on the resource",
                 "https://fedora.info/2018/06/25/spec/#append-ldprs", ps);
 
         final String resourceUri = createResource(uri, info.getId());

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -593,14 +593,39 @@ public class WebACModes extends AbstractAuthzTest {
     }
 
     /**
-     * 5.7.1-B acl:Append for LDP-RS SHOULD test conditions
+     * 5.7.1-B acl:Append for LDP-RS MUST if PUT to create test conditions
      *
-     * @param uri
+     * @param uri of base container of Fedora server
+     */
+    @Test(groups = { "MUST" })
+    @Parameters({ "param1" })
+    public void appendNotWritePutToCreate(final String uri) {
+        final TestInfo info = setupTest("5.7.1-B", "appendNotWritePutToCreate",
+                "When a client has acl:Append but not acl:Write for an LDP-RS and the " +
+                        "implementation supports PUT to create they MUST " +
+                        "allow the addition of a new child resource.",
+                "https://fedora.info/2018/06/25/spec/#append-ldprs", ps);
+
+        final String resourceUri = createResource(uri, info.getId());
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+
+        // perform PUT to child resource as non-admin succeeds.
+        final Response putChildResponse =
+                doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
+                        "test", false);
+        // verify successful
+        putChildResponse.then().statusCode(201);
+    }
+
+    /**
+     * 5.7.1-C acl:Append for LDP-RS SHOULD test conditions
+     *
+     * @param uri of base container of Fedora server
      */
     @Test(groups = { "SHOULD" })
     @Parameters({ "param1" })
     public void appendNotWriteLdpRsShould(final String uri) {
-        final TestInfo info = setupTest("5.7.1-B", "appendNotWriteLdpRsShould",
+        final TestInfo info = setupTest("5.7.1-C", "appendNotWriteLdpRsShould",
                 "When a client has acl:Append but not acl:Write for an LDP-RS they SHOULD " +
                         "allow a PATCH request that only adds triples.",
                 "https://fedora.info/2018/06/25/spec/#append-ldprs", ps);
@@ -625,4 +650,5 @@ public class WebACModes extends AbstractAuthzTest {
         // Verify success.
         patchAddData.then().statusCode(204);
     }
+
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -539,4 +539,90 @@ public class WebACModes extends AbstractAuthzTest {
         childAclResponse.then().statusCode(403);
     }
 
+    /**
+     * 5.7.1-A acl:Append for LDP-RS MUST test conditions
+     *
+     * @param uri of base container of Fedora server
+     */
+    @Test(groups = { "MUST" })
+    @Parameters({ "param1" })
+    public void appendNotWriteLdpRsMust(final String uri) {
+        final TestInfo info = setupTest("5.7.1-A", "appendNotWriteLdpRsMust",
+                "When a client has acl:Append but not acl:Write for an LDP-RS they MUST " +
+                        "not DELETE, not PATCH that deletes triples, not PUT on the resource, and " +
+                        "must be able to PUT a child resource",
+                "https://fedora.info/2018/06/25/spec/#append-ldprs", ps);
+
+        final String resourceUri = createResource(uri, info.getId());
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+
+        // perform DELETE to resource as non-admin
+        final Response deleteResponse = doDeleteUnverified(resourceUri, false);
+        // verify failure.
+        deleteResponse.then().statusCode(403);
+
+        // perform PUT to resource as non-admin
+        final Response putResponse =
+                doPutUnverified(resourceUri, new Headers(new Header("Content-Type", "text/plain")),
+                        "test", false);
+        // verify failure.
+        putResponse.then().statusCode(403);
+
+        // perform PUT to child resource as non-admin succeeds.
+        final Response putChildResponse =
+                doPutUnverified(resourceUri + "/child1", new Headers(new Header("Content-Type", "text/plain")),
+                        "test", false);
+        // verify successful
+        putChildResponse.then().statusCode(201);
+
+        // perform PATCH which also deletes.
+        final Response patchDelete = doPatchUnverified(resourceUri, new Headers(new Header("Content-type",
+                "application/sparql-update")),
+                "prefix dc: <http://purl.org/dc/elements/1.1/> DELETE { <> dc:title ?o1 .}" +
+                        " INSERT { <> dc:title \"I made a change\" .} WHERE { <> dc:title ?o1 .}",
+                false);
+        // Verify failure.
+        patchDelete.then().statusCode(403);
+
+        final Response patchDeleteData = doPatchUnverified(resourceUri, new Headers(new Header("Content-type",
+                "application/sparql-update")),
+                "prefix dc: <http://purl.org/dc/elements/1.1/> DELETE DATA { <> dc:title \"Some title\" .}",
+                false);
+        // Verify failure.
+        patchDeleteData.then().statusCode(403);
+    }
+
+    /**
+     * 5.7.1-B acl:Append for LDP-RS SHOULD test conditions
+     *
+     * @param uri
+     */
+    @Test(groups = { "SHOULD" })
+    @Parameters({ "param1" })
+    public void appendNotWriteLdpRsShould(final String uri) {
+        final TestInfo info = setupTest("5.7.1-B", "appendNotWriteLdpRsShould",
+                "When a client has acl:Append but not acl:Write for an LDP-RS they SHOULD " +
+                        "allow a PATCH request that only adds triples.",
+                "https://fedora.info/2018/06/25/spec/#append-ldprs", ps);
+
+        final String resourceUri = createResource(uri, info.getId());
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+
+        // perform PATCH which only adds.
+        final Response patchAdd = doPatchUnverified(resourceUri, new Headers(new Header("Content-type",
+                "application/sparql-update")),
+                "prefix dc: <http://purl.org/dc/elements/1.1/> DELETE { } INSERT { <> dc:title \"I made a change\" .}" +
+                        " WHERE { }",
+                false);
+        // Verify success.
+        patchAdd.then().statusCode(204);
+
+        // perform PATCH which only adds.
+        final Response patchAddData = doPatchUnverified(resourceUri, new Headers(new Header("Content-type",
+                "application/sparql-update")),
+                "prefix dc: <http://purl.org/dc/elements/1.1/> INSERT DATA { <> dc:title \"I made a change\" .}",
+                false);
+        // Verify success.
+        patchAddData.then().statusCode(204);
+    }
 }


### PR DESCRIPTION
Resolves #188 

The **MUST** PUT a child resource is contingent on the implementation allowing create on PUT. 

Not sure how we check for that so I left it in the MUST for now.