### PR TITLE
5.7.3 acl:Append not acl:Write on LDP-NR

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -560,20 +560,6 @@ public class AbstractTest {
     }
 
     /**
-     * Does the returned Allow header have desired operation.
-     *
-     * @param resource the URI of the resource.
-     * @param op the operation desired.
-     * @return true if the operation is in the Allow header.
-     */
-    protected boolean isOperationAllowed(final String resource, final String op) {
-        final Response response = doHead(resource);
-        return getHeaders(response, "Allow")
-                .flatMap(header -> Arrays.stream(header.getValue().split(","))).anyMatch(allow -> op.toUpperCase()
-                        .equals(allow));
-    }
-
-    /**
      * Confirm the response contains one of the 3 Container types.
      *
      * @param response the request response.

--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -307,16 +307,27 @@ public class AbstractTest {
         return response;
     }
 
-    private Response doOptionsUnverified(final String uri) {
-        return createRequest().when().options(uri);
+    private Response doOptionsUnverified(final String uri, final boolean admin) {
+        return createRequest(admin).when().options(uri);
     }
 
-    protected Response doOptions(final String uri) {
-        final Response response = doOptionsUnverified(uri);
+    /**
+     * Do an options request.
+     *
+     * @param uri the URI of the request
+     * @param admin whether to use admin user credentials
+     * @return the response
+     */
+    protected Response doOptions(final String uri, final boolean admin) {
+        final Response response = doOptionsUnverified(uri, admin);
 
         response.then().statusCode(200);
 
         return response;
+    }
+
+    protected Response doOptions(final String uri) {
+        return doOptions(uri, true);
     }
 
     private RequestSpecification createRequest() {
@@ -536,6 +547,19 @@ public class AbstractTest {
     }
 
     /**
+     * Does the returned Allow header have desired operation.
+     *
+     * @param response the response.
+     * @param op the operation desired.
+     * @return true if the operation is in the Allow header.
+     */
+    protected boolean isOperationAllowed(final Response response, final String op) {
+        return getHeaders(response, "Allow")
+                .flatMap(header -> Arrays.stream(header.getValue().split(","))).anyMatch(allow -> op.toUpperCase()
+                        .equals(allow));
+    }
+
+    /**
      * Confirm the response contains one of the 3 Container types.
      *
      * @param response the request response.
@@ -555,4 +579,5 @@ public class AbstractTest {
         containers.add(URI.create("http://www.w3.org/ns/ldp#DirectContainer"));
         return containers.contains(p);
     });
+
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -127,8 +127,14 @@ public class AbstractTest {
     }
 
     /**
-     * A convenience method for setup boilerplate which attempts to automatically
-     * set the name of the test method which directly invoked this setup.
+     * A convenience method for setup boilerplate which attempts to automatically set the name of the test method
+     * which directly invoked this setup.
+     *
+     * @param id Test ID
+     * @param description Description of the test
+     * @param specLink Link to the API specification we are testing
+     * @param ps PrintStream to add the TestInfo to.
+     * @return The TestInfo
      */
     protected TestInfo setupTest(final String id, final String description, final String specLink,
             final PrintStream ps) {
@@ -144,6 +150,13 @@ public class AbstractTest {
 
     /**
      * A convenience method for setup boilerplate
+     *
+     * @param id Test ID
+     * @param title Test name
+     * @param description Description of the test
+     * @param specLink Link to the API specification we are testing
+     * @param ps PrintStream to add the TestInfo to.
+     * @return The TestInfo
      */
     protected TestInfo setupTest(final String id, final String title, final String description, final String specLink,
                                  final PrintStream ps) {
@@ -549,11 +562,12 @@ public class AbstractTest {
     /**
      * Does the returned Allow header have desired operation.
      *
-     * @param response the response.
+     * @param resource the URI of the resource.
      * @param op the operation desired.
      * @return true if the operation is in the Allow header.
      */
-    protected boolean isOperationAllowed(final Response response, final String op) {
+    protected boolean isOperationAllowed(final String resource, final String op) {
+        final Response response = doHead(resource);
         return getHeaders(response, "Allow")
                 .flatMap(header -> Arrays.stream(header.getValue().split(","))).anyMatch(allow -> op.toUpperCase()
                         .equals(allow));
@@ -580,4 +594,16 @@ public class AbstractTest {
         return containers.contains(p);
     });
 
+    /**
+     * Get the LDP-RS that describes a LDP-NR if it exists.
+     *
+     * @param ldpNrUri the uri of the LDP-NR
+     * @return the uri of the describing LDP-RS or null
+     */
+    protected String getLdpNrDescription(final String ldpNrUri) {
+        final Response response = doHead(ldpNrUri);
+        return getLinksOfRelType(response, "describedby").map(Link::getUri)
+                .map(URI::toString)
+                .findFirst().orElse(null);
+    }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -76,7 +76,7 @@ public class App {
 
         final CommandLineParser parser = new BasicParser();
         final HelpFormatter formatter = new HelpFormatter();
-        CommandLine cmd;
+        final CommandLine cmd;
         try {
             cmd = parser.parse(options, args);
         } catch (final ParseException e) {

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -18,8 +18,6 @@
 package org.fcrepo.spec.testsuite.authz;
 
 import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
-import static org.junit.Assert.fail;
-
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
@@ -740,7 +738,6 @@ public class WebACModes extends AbstractAuthzTest {
         createAclForResource(resourceUri, "user-read-append.ttl", this.username);
 
         final String description = getLdpNrDescription(resourceUri);
-        final boolean patchLDPNR = isOperationAllowed(resourceUri, "PATCH");
 
         if (description != null) {
             // perform PATCH which also deletes.
@@ -760,12 +757,6 @@ public class WebACModes extends AbstractAuthzTest {
             patchDeleteData.then().statusCode(403);
         }
 
-        if (patchLDPNR) {
-            final Response headResponse = doHead(resourceUri, false);
-            final String allowPatch = getHeaders(headResponse, "Allow-Patch").findFirst().map(Header::getValue).get();
-            // How are we testing patching an LDP-NR? Xdiff?
-            fail("This test suite has not implemented LDP-NR patch testing.");
-        }
     }
 
     /**
@@ -788,7 +779,6 @@ public class WebACModes extends AbstractAuthzTest {
         createAclForResource(resourceUri, "user-read-append.ttl", this.username);
 
         final String description = getLdpNrDescription(resourceUri);
-        final boolean patchLDPNR = isOperationAllowed(resourceUri, "PATCH");
 
         if (description != null) {
             // perform PATCH which only adds.
@@ -809,11 +799,5 @@ public class WebACModes extends AbstractAuthzTest {
             patchAddData.then().statusCode(204);
         }
 
-        if (patchLDPNR) {
-            final Response headResponse = doHead(resourceUri, false);
-            final String allowPatch = getHeaders(headResponse, "Allow-Patch").findFirst().map(Header::getValue).get();
-            // How are we testing patching an LDP-NR? Xdiff?
-            fail("This test suite has not implemented LDP-NR patch testing.");
-        }
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -18,6 +18,11 @@
 package org.fcrepo.spec.testsuite.authz;
 
 import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+
+import javax.ws.rs.core.Link;
 
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
@@ -648,7 +653,7 @@ public class WebACModes extends AbstractAuthzTest {
     /**
      * 5.7.2 acl:Append for LDP-C MUST test conditions
      *
-     * @param uri
+     * @param uri of base container of Fedora server
      */
     @Test(groups = { "MUST" })
     @Parameters({ "param1" })
@@ -669,4 +674,157 @@ public class WebACModes extends AbstractAuthzTest {
         }
     }
 
+    /**
+     * 5.7.3-A acl:Append for LDP-NR MUST test conditions
+     *
+     * @param uri of base container of Fedora server
+     */
+    @Test(groups = { "MUST" })
+    @Parameters({ "param1" })
+    public void appendNotWriteLdpNr(final String uri) {
+        final TestInfo info = setupTest("5.7.3-A",
+                "When a client has acl:Append but not acl:Write for an LDP-NR they MUST " +
+                        "deny all DELETE, POST, and PUT requests.",
+                "https://fedora.info/2018/06/25/spec/#append-ldpnr", ps);
+
+        final Headers headers = new Headers(new Header("Content-type", "text/plain"));
+        final Response postLdpNr = doPost(uri, headers, "test image");
+        final String resourceUri = getLocation(postLdpNr);
+
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+
+        final Response getResponse = doHead(resourceUri, false);
+        final String description = getLinksOfRelType(getResponse, "describedby").map(Link::getUri)
+                .map(URI::toString)
+                .findFirst().orElse(null);
+
+        // POST requests to a LDP-NR with acl:Append only MUST be denied
+        final Response postRequest = doPostUnverified(resourceUri, null, null, false);
+        postRequest.then().statusCode(403);
+
+        // PUT requests to a LDP-NR with acl:Append only MUST be denied
+        final Response putRequest = doPutUnverified(resourceUri, null, null, false);
+        putRequest.then().statusCode(403);
+
+        // DELETE requests to a LDP-NR with acl:Append only MUST be denied
+        final Response deleteRequest = doDeleteUnverified(resourceUri, false);
+        deleteRequest.then().statusCode(403);
+
+        // Also perform the tests against an associated LDP-RS.
+        if (description != null) {
+            // POST requests to a LDP-NR with acl:Append only MUST be denied
+            final Response postRequest2 = doPostUnverified(description, null, null, false);
+            postRequest2.then().statusCode(403);
+
+            // PUT requests to a LDP-NR with acl:Append only MUST be denied
+            final Response putRequest2 = doPutUnverified(description, null, null, false);
+            putRequest2.then().statusCode(403);
+
+            // DELETE requests to a LDP-NR with acl:Append only MUST be denied
+            final Response deleteRequest2 = doDeleteUnverified(description, false);
+            deleteRequest2.then().statusCode(403);
+        }
+
+    }
+
+    /**
+     * 5.7.3-B acl:Append for LDP-NR MUST PATCH test conditions.
+     *
+     * @param uri of base container of Fedora server
+     */
+    @Test(groups = { "MUST" })
+    @Parameters({ "param1" })
+    public void appendNotWriteLdpNrPatchMust(final String uri) {
+        final TestInfo info = setupTest("5.7.3-B",
+                "When a client has acl:Append but not acl:Write for an LDP-NR they MUST " +
+                        "deny all PATCH requests that delete or modify existing content.",
+                "https://fedora.info/2018/06/25/spec/#append-ldpnr", ps);
+
+        final Headers headers = new Headers(new Header("Content-type", "text/plain"));
+        final Response postLdpNr = doPost(uri, headers, "test image");
+        final String resourceUri = getLocation(postLdpNr);
+
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+
+        final Response getResponse = doHead(resourceUri, false);
+        final String description = getLinksOfRelType(getResponse, "describedby").map(Link::getUri)
+                .map(URI::toString)
+                .findFirst().orElse(null);
+        final boolean patchLDPNR = isOperationAllowed(getResponse, "PATCH");
+
+        if (description != null) {
+            // perform PATCH which also deletes.
+            final Response patchDelete = doPatchUnverified(description, new Headers(new Header("Content-type",
+                    "application/sparql-update")),
+                    "prefix dc: <http://purl.org/dc/elements/1.1/> DELETE { <> dc:title ?o1 .}" +
+                            " INSERT { <> dc:title \"I made a change\" .} WHERE { <> dc:title ?o1 .}",
+                    false);
+            // Verify failure.
+            patchDelete.then().statusCode(403);
+
+            final Response patchDeleteData = doPatchUnverified(description, new Headers(new Header("Content-type",
+                    "application/sparql-update")),
+                    "prefix dc: <http://purl.org/dc/elements/1.1/> DELETE DATA { <> dc:title \"Some title\" .}",
+                    false);
+            // Verify failure.
+            patchDeleteData.then().statusCode(403);
+        }
+
+        if (patchLDPNR) {
+            final String allowPatch = getHeaders(getResponse, "Allow-Patch").findFirst().map(Header::getValue).get();
+            // How are we testing patching an LDP-NR? Xdiff?
+            fail("This test suite has not implemented LDP-NR patch testing.");
+        }
+    }
+
+    /**
+     * 5.7.3-C acl:Append for LDP-NR SHOULD PATCH test conditions.
+     *
+     * @param uri of base container of Fedora server
+     */
+    @Test(groups = { "SHOULD" })
+    @Parameters({ "param1" })
+    public void appendNotWriteLdpNrPatchShould(final String uri) {
+        final TestInfo info = setupTest("5.7.3-C",
+                "When a client has acl:Append but not acl:Write for an LDP-NR they SHOULD " +
+                        "allow all PATCH requests that only add new content.",
+                "https://fedora.info/2018/06/25/spec/#append-ldpnr", ps);
+
+        final Headers headers = new Headers(new Header("Content-type", "text/plain"));
+        final Response postLdpNr = doPost(uri, headers, "test image");
+        final String resourceUri = getLocation(postLdpNr);
+
+        createAclForResource(resourceUri, "user-read-append.ttl", this.username);
+
+        final Response getResponse = doHead(resourceUri, false);
+        final String description = getLinksOfRelType(getResponse, "describedby").map(Link::getUri)
+                .map(URI::toString)
+                .findFirst().orElse(null);
+        final boolean patchLDPNR = isOperationAllowed(getResponse, "PATCH");
+
+        if (description != null) {
+            // perform PATCH which only adds.
+            final Response patchAdd = doPatchUnverified(description, new Headers(new Header("Content-type",
+                    "application/sparql-update")),
+                    "prefix dc: <http://purl.org/dc/elements/1.1/> DELETE { } INSERT " +
+                            "{ <> dc:title \"I made a change\" .} WHERE { }",
+                    false);
+            // Verify success.
+            patchAdd.then().statusCode(204);
+
+            // perform PATCH which only adds.
+            final Response patchAddData = doPatchUnverified(description, new Headers(new Header("Content-type",
+                    "application/sparql-update")),
+                    "prefix dc: <http://purl.org/dc/elements/1.1/> INSERT DATA { <> dc:title \"I made a change\" .}",
+                    false);
+            // Verify success.
+            patchAddData.then().statusCode(204);
+        }
+
+        if (patchLDPNR) {
+            final String allowPatch = getHeaders(getResponse, "Allow-Patch").findFirst().map(Header::getValue).get();
+            // How are we testing patching an LDP-NR? Xdiff?
+            fail("This test suite has not implemented LDP-NR patch testing.");
+        }
+    }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACModes.java
@@ -20,10 +20,6 @@ package org.fcrepo.spec.testsuite.authz;
 import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
 import static org.junit.Assert.fail;
 
-import java.net.URI;
-
-import javax.ws.rs.core.Link;
-
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
@@ -693,10 +689,7 @@ public class WebACModes extends AbstractAuthzTest {
 
         createAclForResource(resourceUri, "user-read-append.ttl", this.username);
 
-        final Response getResponse = doHead(resourceUri, false);
-        final String description = getLinksOfRelType(getResponse, "describedby").map(Link::getUri)
-                .map(URI::toString)
-                .findFirst().orElse(null);
+        final String description = getLdpNrDescription(resourceUri);
 
         // POST requests to a LDP-NR with acl:Append only MUST be denied
         final Response postRequest = doPostUnverified(resourceUri, null, null, false);
@@ -746,11 +739,8 @@ public class WebACModes extends AbstractAuthzTest {
 
         createAclForResource(resourceUri, "user-read-append.ttl", this.username);
 
-        final Response getResponse = doHead(resourceUri, false);
-        final String description = getLinksOfRelType(getResponse, "describedby").map(Link::getUri)
-                .map(URI::toString)
-                .findFirst().orElse(null);
-        final boolean patchLDPNR = isOperationAllowed(getResponse, "PATCH");
+        final String description = getLdpNrDescription(resourceUri);
+        final boolean patchLDPNR = isOperationAllowed(resourceUri, "PATCH");
 
         if (description != null) {
             // perform PATCH which also deletes.
@@ -771,7 +761,8 @@ public class WebACModes extends AbstractAuthzTest {
         }
 
         if (patchLDPNR) {
-            final String allowPatch = getHeaders(getResponse, "Allow-Patch").findFirst().map(Header::getValue).get();
+            final Response headResponse = doHead(resourceUri, false);
+            final String allowPatch = getHeaders(headResponse, "Allow-Patch").findFirst().map(Header::getValue).get();
             // How are we testing patching an LDP-NR? Xdiff?
             fail("This test suite has not implemented LDP-NR patch testing.");
         }
@@ -796,11 +787,8 @@ public class WebACModes extends AbstractAuthzTest {
 
         createAclForResource(resourceUri, "user-read-append.ttl", this.username);
 
-        final Response getResponse = doHead(resourceUri, false);
-        final String description = getLinksOfRelType(getResponse, "describedby").map(Link::getUri)
-                .map(URI::toString)
-                .findFirst().orElse(null);
-        final boolean patchLDPNR = isOperationAllowed(getResponse, "PATCH");
+        final String description = getLdpNrDescription(resourceUri);
+        final boolean patchLDPNR = isOperationAllowed(resourceUri, "PATCH");
 
         if (description != null) {
             // perform PATCH which only adds.
@@ -822,7 +810,8 @@ public class WebACModes extends AbstractAuthzTest {
         }
 
         if (patchLDPNR) {
-            final String allowPatch = getHeaders(getResponse, "Allow-Patch").findFirst().map(Header::getValue).get();
+            final Response headResponse = doHead(resourceUri, false);
+            final String allowPatch = getHeaders(headResponse, "Allow-Patch").findFirst().map(Header::getValue).get();
             // How are we testing patching an LDP-NR? Xdiff?
             fail("This test suite has not implemented LDP-NR patch testing.");
         }


### PR DESCRIPTION
Resolves: #191 
Relies on #207 

This is built on top of an existing PR, so #207 should be merged first and then this one rebased.

This adds 3 tests for section 5.7.3 acl:Append on an LDP-NR

It has a path for the conceivable `PATCH`ing of the actual `LDP-NR` (instead of an associated `LDP-RS`) but that is an open question (https://github.com/fcrepo/fcrepo-specification/issues/400)

Currently it fails if you get there.

These tests all fail against the community implementation due to https://jira.duraspace.org/browse/FCREPO-2867