### PR TITLE
Where applicable the test suite tries  first to create mementos via t…

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
@@ -107,7 +107,7 @@ public class AbstractVersioningTest extends AbstractTest {
                                                                  final Response response) {
         Assert
             .assertFalse(hasHeaderValueInMultiValueHeader(headerName, headerValue, response),
-                         headerName + " with a value of " + headerValue + " must be not present but it is!");
+                        headerName + " with a value of " + headerValue + " must be not present but it is!");
     }
 
     protected boolean hasHeaderValueInMultiValueHeader(final String headerName, final String headerValue,
@@ -127,10 +127,12 @@ public class AbstractVersioningTest extends AbstractTest {
         assertEquals(mementoDateTime, dateTime, "Memento-Datetime header does not match expected");
     }
 
+
     protected void confirmPresenceOfVersionLocationHeader(final Response response) {
         final String location = response.getHeader("Location");
         Assert.assertTrue(location.contains("fcr:versions"));
     }
+
 
     protected void confirmAbsenceOfLinkValue(final String linkValue, final Response response) {
         final Link link = Link.valueOf(linkValue);
@@ -160,11 +162,10 @@ public class AbstractVersioningTest extends AbstractTest {
     /**
      * Given the URI of the original resource, create a memento based on the
      * specified body.
-     *
      * @param originalResourceUri The resource to be memento-ized.
-     * @param mementoDateTime     the memento datetime
-     * @param contentType         the content Type of the memento
-     * @param body                the body of the memento
+     * @param mementoDateTime the memento datetime
+     * @param contentType the content Type of the memento
+     * @param body the body of the memento
      * @return The uri of the newly created memento
      */
     protected String createMemento(final String originalResourceUri, final String mementoDateTime,
@@ -174,7 +175,7 @@ public class AbstractVersioningTest extends AbstractTest {
         final Headers headers = new Headers(new Header("Content-Type", contentType),
                                             new Header(MEMENTO_DATETIME_HEADER, mementoDateTime));
 
-        final Response timeMapResponse = doPost(timeMapURI.toString(), headers, body);
+        final Response timeMapResponse = doPost(timeMapURI.toString(),headers, body);
         return getLocation(timeMapResponse);
     }
 
@@ -191,8 +192,8 @@ public class AbstractVersioningTest extends AbstractTest {
         } else {
             // otherwise create a memento by altering the original resource and retrieving the most recent memento
             //if ldp-rs
-
-            if (getLinksOfRelType(response, "type").anyMatch(link -> link.equals(RDF_SOURCE_LINK_HEADER))) {
+            if (getLinksOfRelType(response, "type")
+                .anyMatch(link -> link.equals(Link.valueOf(RDF_SOURCE_LINK_HEADER)))) {
                 final String body = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
                                     "PREFIX pcdm: <http://pcdm.org/models#>\n" +
                                     "INSERT  {\n" +
@@ -202,7 +203,7 @@ public class AbstractVersioningTest extends AbstractTest {
                         body);
             } else {
                 //otherwise ldp-nr
-                doPut(originalResourceUri, new Headers(new Header("Content-Type", "text")),
+                doPut(originalResourceUri, new Headers(new Header("Content-Type", "text/plain")),
                       "body-" + System.currentTimeMillis());
             }
 

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/AbstractVersioningTest.java
@@ -18,13 +18,17 @@
 
 package org.fcrepo.spec.testsuite.versioning;
 
+import static java.time.Instant.now;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Arrays.sort;
 import static org.fcrepo.spec.testsuite.Constants.CONTENT_DISPOSITION;
 import static org.fcrepo.spec.testsuite.Constants.MEMENTO_DATETIME_HEADER;
 import static org.fcrepo.spec.testsuite.Constants.ORIGINAL_RESOURCE_LINK_HEADER;
+import static org.fcrepo.spec.testsuite.Constants.RDF_SOURCE_LINK_HEADER;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.net.URI;
+import java.time.ZoneId;
 import java.util.Arrays;
 import javax.ws.rs.core.Link;
 
@@ -103,7 +107,7 @@ public class AbstractVersioningTest extends AbstractTest {
                                                                  final Response response) {
         Assert
             .assertFalse(hasHeaderValueInMultiValueHeader(headerName, headerValue, response),
-                        headerName + " with a value of " + headerValue + " must be not present but it is!");
+                         headerName + " with a value of " + headerValue + " must be not present but it is!");
     }
 
     protected boolean hasHeaderValueInMultiValueHeader(final String headerName, final String headerValue,
@@ -123,12 +127,10 @@ public class AbstractVersioningTest extends AbstractTest {
         assertEquals(mementoDateTime, dateTime, "Memento-Datetime header does not match expected");
     }
 
-
     protected void confirmPresenceOfVersionLocationHeader(final Response response) {
         final String location = response.getHeader("Location");
         Assert.assertTrue(location.contains("fcr:versions"));
     }
-
 
     protected void confirmAbsenceOfLinkValue(final String linkValue, final Response response) {
         final Link link = Link.valueOf(linkValue);
@@ -158,10 +160,11 @@ public class AbstractVersioningTest extends AbstractTest {
     /**
      * Given the URI of the original resource, create a memento based on the
      * specified body.
+     *
      * @param originalResourceUri The resource to be memento-ized.
-     * @param mementoDateTime the memento datetime
-     * @param contentType the content Type of the memento
-     * @param body the body of the memento
+     * @param mementoDateTime     the memento datetime
+     * @param contentType         the content Type of the memento
+     * @param body                the body of the memento
      * @return The uri of the newly created memento
      */
     protected String createMemento(final String originalResourceUri, final String mementoDateTime,
@@ -171,14 +174,44 @@ public class AbstractVersioningTest extends AbstractTest {
         final Headers headers = new Headers(new Header("Content-Type", contentType),
                                             new Header(MEMENTO_DATETIME_HEADER, mementoDateTime));
 
-        final Response timeMapResponse = doPost(timeMapURI.toString(),headers, body);
+        final Response timeMapResponse = doPost(timeMapURI.toString(), headers, body);
         return getLocation(timeMapResponse);
+    }
+
+    protected URI getTimeGateUri(final Response response) {
+        return getLinksOfRelTypeAsUris(response, "timegate").findFirst().get();
     }
 
     protected String createMemento(final String originalResourceUri) {
         final Response response = doGet(originalResourceUri);
         final URI timeMapURI = getTimeMapUri(response);
-        final Response timeMapResponse = doPost(timeMapURI.toString());
-        return getLocation(timeMapResponse);
+        if (hasHeaderValueInMultiValueHeader("Allow", "Post", doGet(timeMapURI.toString()))) {
+            //if POST allowed (client-managed versioning)
+            return getLocation(doPost(timeMapURI.toString()));
+        } else {
+            // otherwise create a memento by altering the original resource and retrieving the most recent memento
+            //if ldp-rs
+
+            if (getLinksOfRelType(response, "type").anyMatch(link -> link.equals(RDF_SOURCE_LINK_HEADER))) {
+                final String body = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
+                                    "PREFIX pcdm: <http://pcdm.org/models#>\n" +
+                                    "INSERT  {\n" +
+                                    " <>  rdf:type pcdm:Collection .\n" +
+                                    "} WHERE {}";
+                doPatch(originalResourceUri, new Headers(new Header("Content-Type", "application/sparql-update")),
+                        body);
+            } else {
+                //otherwise ldp-nr
+                doPut(originalResourceUri, new Headers(new Header("Content-Type", "text")),
+                      "body-" + System.currentTimeMillis());
+            }
+
+            final String now = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC")).format(now());
+            final String timeGate = getTimeGateUri(response).toString();
+            //get the most recent memento
+            final Response timeGateResponse = doGetUnverified(timeGate, new Header("Accept-Datetime", now));
+            timeGateResponse.then().statusCode(302);
+            return getLocation(timeGateResponse);
+        }
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpGet.java
@@ -115,8 +115,7 @@ public class LdprvHttpGet extends AbstractVersioningTest {
         //get timegate uri
         final URI timeGateUri = getTimeGateUri(response);
 
-        final Response newMementoResponse = doPost(timeMapURI.toString());
-        final String newMementoUri = getLocation(newMementoResponse);
+        final String newMementoUri = createMemento(resourceUri);
 
         //query timegate using Accept-Datetime
         final String isoDateString = "1970-01-01T00:00:00Z";
@@ -285,11 +284,6 @@ public class LdprvHttpGet extends AbstractVersioningTest {
                             1,
                             "Link with rel type '" + relType + "' must be present but is not!");
     }
-
-    private URI getTimeGateUri(final Response response) {
-        return getLinksOfRelTypeAsUris(response, "timegate").findFirst().get();
-    }
-
 
     private URI getOriginalUri(final Response response) {
         return getLinksOfRelTypeAsUris(response, "original").findFirst().get();


### PR DESCRIPTION
…he client-managed approach but falls back to server-managed approach before failing.
Note:  I wasn't able to test this fully because the Fedora 5.0.0 uses client managed version creation.   Hopefully we'll get feedback other implementations.

Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/217