### PR TITLE
Fedora Test Suite Test 3.5.1-B fails

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPost.java
@@ -20,7 +20,6 @@ package org.fcrepo.spec.testsuite.crud;
 import static org.fcrepo.spec.testsuite.Constants.CONTENT_DISPOSITION;
 import static org.fcrepo.spec.testsuite.Constants.DIGEST;
 import static org.fcrepo.spec.testsuite.Constants.SLUG;
-import static org.hamcrest.Matchers.containsString;
 
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
@@ -96,8 +95,7 @@ public class HttpPost extends AbstractTest {
                 new Header(CONTENT_DISPOSITION, "attachment; filename=\"postResourceAndCheckAssociatedResource.txt\""),
                 new Header(SLUG, info.getId()));
         doPost(uri, headers, "TestString.")
-                .then()
-                .header("Link", containsString("describedby"));
+                .getHeaders().toString().contains("rels=\"describedby\"");
     }
 
     /**


### PR DESCRIPTION
- Multiple LINK headers are received, only last one is recognized.
  Test has been modified to make the headers a string and find exact
  string in that string

Resolves https://jira.duraspace.org/browse/FCREPO-2918