### PR TITLE
Allow any 2xx response codes on PUT responses

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/authz/AbstractAuthzTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/AbstractAuthzTest.java
@@ -84,7 +84,7 @@ public class AbstractAuthzTest extends AbstractTest {
         //create read acl for user role
         final Response response = doPutUnverified(aclUri, new Headers(new Header("Content-Type", "text/turtle")),
                                                   getAclAsString(aclFileName, resourceUri, username));
-        response.then().statusCode(201);
+        response.then().statusCode(successRange());
         return aclUri;
     }
 
@@ -95,7 +95,7 @@ public class AbstractAuthzTest extends AbstractTest {
         //create read acl for user role
         final Response response = doPutUnverified(aclUri, new Headers(new Header("Content-Type", "text/turtle")),
                                                   filterFileAndConvertToString(aclFileName, aclParams));
-        response.then().statusCode(201);
+        response.then().statusCode(successRange());
         return aclUri;
     }
 


### PR DESCRIPTION
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/233