### PR TITLE
Omit charset from Content-Type header

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -461,7 +461,8 @@ public class AbstractTest {
     protected Response doPatchUnverified(final String uri, final Headers headers, final String body,
                                          final boolean admin) {
         final RequestSpecification req = createRequest(admin).config(RestAssured.config().encoderConfig(
-                new EncoderConfig().encodeContentTypeAs(APPLICATION_SPARQL_UPDATE, ContentType.TEXT)));
+                new EncoderConfig().encodeContentTypeAs(APPLICATION_SPARQL_UPDATE, ContentType.TEXT)
+        .appendDefaultContentCharsetToContentTypeIfUndefined(false)));
         if (headers != null) {
             req.headers(headers);
         }


### PR DESCRIPTION
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/236