### PR TITLE
Skip non-supported crud.ExternalBinaryContent tests

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/ExternalBinaryContent.java
@@ -120,6 +120,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "copy")),
                 new Header(SLUG, info.getId()));
@@ -140,6 +144,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "copy")),
@@ -162,6 +170,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "redirect")),
                 new Header(SLUG, info.getId()));
@@ -181,6 +193,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "redirect")),
@@ -202,6 +218,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "proxy")),
                 new Header(SLUG, info.getId()));
@@ -222,6 +242,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "proxy")),
                 new Header(SLUG, info.getId()));
@@ -241,6 +265,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final String location = joinLocation(uri, info.getId());
         final Headers headers = new Headers(
@@ -263,6 +291,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final String location = joinLocation(uri, info.getId());
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "copy")));
@@ -283,6 +315,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final String location = joinLocation(uri, info.getId());
         final Headers headers = new Headers(
@@ -305,6 +341,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final String location = joinLocation(uri, info.getId());
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "redirect")));
@@ -325,6 +365,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final String location = joinLocation(uri, info.getId());
         final Headers headers = new Headers(
@@ -347,6 +391,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final String location = joinLocation(uri, info.getId());
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalFileUri, "proxy")));
@@ -367,6 +415,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final String locationHeader = createNonRdfSource(uri, info.getId());
 
@@ -389,6 +441,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
@@ -409,6 +465,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final String locationHeader = createNonRdfSource(uri, info.getId());
 
@@ -431,6 +491,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
@@ -452,6 +516,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final String locationHeader = createNonRdfSource(uri, info.getId());
 
         final Headers headers2 = new Headers(
@@ -472,6 +540,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "request entity, as indicated by a link with " +
                         "rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final String locationHeader = createNonRdfSource(uri, info.getId());
 
@@ -544,6 +616,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "copy, redirect, and/or proxy.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final List<String> acceptedHandlingTypes = getAcceptedHandlingTypes(uri);
 
         final List<String> acceptedAndExpected = acceptedHandlingTypes.stream()
@@ -576,6 +652,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "is not present or cannot be respected.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, null)),
                 new Header(SLUG, info.getId()));
@@ -599,6 +679,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "rel=\"http://www.w3.org/ns/ldp#constrainedBy\" link in the Link response header.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "unsupported")),
                 new Header(SLUG, info.getId()));
@@ -620,6 +704,10 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers must use the value of the type attribute in the external content link as the media " +
                         "type of the external content, if provided.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUriWithNoType, "proxy", "text/special")),
@@ -646,6 +734,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "specified scheme (e.g. the Content-Type header for external content accessed via http).",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "proxy")),
                 new Header(SLUG, info.getId()));
@@ -668,6 +760,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "type of the external content, if provided. If there is no type attribute: " +
                         "Servers may use a default media type.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUriWithNoType, "proxy")),
@@ -693,6 +789,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "Servers may reject the request with a 4xx range status code.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUriWithNoType, "proxy")),
                 new Header(SLUG, info.getId()));
@@ -713,6 +813,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "type of the external content, if provided. Any Content-Type header in the request should be " +
                         "ignored.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "proxy", "text/special")),
@@ -740,6 +844,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "ignored.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         // Providing external content which does not return Content-Type
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUriWithNoType, "proxy", "text/special")),
@@ -764,6 +872,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "the request entity must reject request if it cannot guarantee all of the response headers " +
                         "required by the LDP-NR interaction model in this specification.",
                 "https://fcrepo.github.io/fcrepo-specification/#external-content", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final String location = createExternalBinary(uri, info.getId(), "proxy", null);
 
@@ -792,6 +904,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "header in response to \"OPTIONS\" request.",
                 "https://fedora.info/2018/06/25/spec/#external-content-options", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         doOptions(uri).then()
                 .assertThat().header("Accept-External-Content-Handling", is(notNullValue()));
     }
@@ -808,6 +924,10 @@ public class ExternalBinaryContent extends AbstractTest {
                 "Fedora servers supporting \"redirect\" external content types MUST correctly respond to the " +
                         "\"Want-Digest\" header.",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final String location = createExternalBinary(uri, info.getId(), "redirect", null);
 
@@ -833,6 +953,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "\"Want-Digest\" header.",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final String location = createExternalBinary(uri, info.getId(), "proxy", null);
 
         final String checksum = "md5;q=0.3,sha;q=1";
@@ -857,6 +981,10 @@ public class ExternalBinaryContent extends AbstractTest {
                         "must have status code of either 302 (Found) or 307 (Temporary Redirect)",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
 
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
+
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "redirect")),
                 new Header(SLUG, info.getId()));
@@ -878,6 +1006,10 @@ public class ExternalBinaryContent extends AbstractTest {
                 "A successful response to a HEAD request for external content with handling of redirect " +
                         "must have status code of either 302 (Found) or 307 (Temporary Redirect)",
                 "https://fedora.info/2018/06/25/spec/#redirect-and-proxy", ps);
+
+        if (!externalContentSupported(uri)) {
+            throw new SkipException("External Binaries are NOT supported");
+        }
 
         final Headers headers = new Headers(
                 new Header(LINK, externalContentHeader(externalUri, "redirect")),


### PR DESCRIPTION
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/270