### PR TITLE
Adds missing DirectContainer tests specified in 3.1.2.

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
@@ -20,21 +20,37 @@ package org.fcrepo.spec.testsuite.crud;
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetImpl;
 import org.fcrepo.spec.testsuite.AbstractTest;
 import org.fcrepo.spec.testsuite.TestInfo;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
+import static org.apache.jena.graph.Node.ANY;
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.spec.testsuite.Constants.DIRECT_CONTAINER_BODY;
 import static org.fcrepo.spec.testsuite.Constants.INDIRECT_CONTAINER_BODY;
 import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.fail;
+
+import java.io.InputStream;
 
 /**
- * @author Jorge Abrego, Fernando Cardoza
+ * @author Jorge Abrego, Fernando Cardoza, dbernstein
  */
 public class Container extends AbstractTest {
+
+    public static final String LDP_CONTAINS_PREDICATE = "http://www.w3.org/ns/ldp#contains";
+    public static final String LDP_MEMBERSHIP_RESOURCE_PREDICATE = "http://www.w3.org/ns/ldp#membershipResource";
+    public static final String LDP_HAS_MEMBER_RELATION_PREDICATE = "http://www.w3.org/ns/ldp#hasMemberRelation";
+    public static final String LDP_IS_MEMBER_OF_RELATION_PREDICATE = "http://www.w3.org/ns/ldp#isMemberOfRelation";
+    public static final String LDP_MEMBER = "http://www.w3.org/ns/ldp#member";
 
     /**
      * 3.1.1-A-1
@@ -120,20 +136,12 @@ public class Container extends AbstractTest {
         ps.append(body);
 
         // Verify presence of expected triple in response body
-        final org.apache.jena.rdf.model.Statement triple = ResourceFactory.createStatement(
-                ResourceFactory.createResource(getLocation(container)),
-                ResourceFactory.createProperty("http://www.w3.org/ns/ldp#contains"),
-                ResourceFactory.createResource(getLocation(containerChild)));
-
-        resP.then().body(new TripleMatcher(triple));
+        confirmPresenceOrAbsenceOfTripleInResponse(resP, getLocation(container), LDP_CONTAINS_PREDICATE,
+                                                   getLocation(containerChild), true);
 
         // Verify absence of unexpected triple in response body
-        final org.apache.jena.rdf.model.Statement badTriple = ResourceFactory.createStatement(
-                ResourceFactory.createResource(getLocation(container)),
-                ResourceFactory.createProperty("http://www.w3.org/ns/ldp#contains"),
-                ResourceFactory.createResource(getLocation(directMember)));
-
-        resP.then().body(new TripleMatcher(badTriple, false));
+        confirmPresenceOrAbsenceOfTripleInResponse(resP, getLocation(container), LDP_CONTAINS_PREDICATE,
+                                                   getLocation(directMember), false);
     }
 
     /**
@@ -177,13 +185,13 @@ public class Container extends AbstractTest {
             // Contained triple
             final org.apache.jena.rdf.model.Statement tripleContained = ResourceFactory.createStatement(
                     ResourceFactory.createResource(getLocation(container)),
-                    ResourceFactory.createProperty("http://www.w3.org/ns/ldp#contains"),
+                    ResourceFactory.createProperty(LDP_CONTAINS_PREDICATE),
                     ResourceFactory.createResource(getLocation(containerChild)));
 
             // Member triple
             final org.apache.jena.rdf.model.Statement tripleMember = ResourceFactory.createStatement(
                     ResourceFactory.createResource(getLocation(container)),
-                    ResourceFactory.createProperty("http://www.w3.org/ns/ldp#contains"),
+                    ResourceFactory.createProperty(LDP_CONTAINS_PREDICATE),
                     ResourceFactory.createResource(getLocation(directMember)));
 
             // Both triples should be ldp:contained
@@ -254,20 +262,458 @@ public class Container extends AbstractTest {
         ps.append(body);
 
         // Verify absence of contained triple in response body
-        final org.apache.jena.rdf.model.Statement tripleContained = ResourceFactory.createStatement(
-                ResourceFactory.createResource(getLocation(container)),
-                ResourceFactory.createProperty("http://www.w3.org/ns/ldp#contains"),
-                ResourceFactory.createResource(getLocation(containerChild)));
+        confirmPresenceOrAbsenceOfTripleInResponse(resP, getLocation(container), LDP_CONTAINS_PREDICATE,
+                                                   getLocation(containerChild), false);
 
-        resP.then().body(new TripleMatcher(tripleContained, false));
-
-        // Verify absence of member triple in response body
-        final org.apache.jena.rdf.model.Statement tripleMember = ResourceFactory.createStatement(
-                ResourceFactory.createResource(getLocation(container)),
-                ResourceFactory.createProperty("http://www.w3.org/ns/ldp#contains"),
-                ResourceFactory.createResource(getLocation(directMember)));
-
-        resP.then().body(new TripleMatcher(tripleMember, false));
+        confirmPresenceOrAbsenceOfTripleInResponse(resP, getLocation(container), LDP_CONTAINS_PREDICATE,
+                                                   getLocation(directMember), false);
     }
 
+    private void confirmPresenceOrAbsenceOfTripleInResponse(final Response response, final String subjectUri,
+                                                            final String predicateUri, final String objectUri,
+                                                            final boolean present) {
+
+        if (!testForPresenceOfTrip(response, subjectUri, predicateUri, objectUri, present)) {
+            if (present) {
+                fail("Triple should have been present but wasn't.");
+            } else {
+                fail("Triple should not have been present but was.");
+            }
+        }
+    }
+
+    private boolean testForPresenceOfTrip(final Response response, final String subjectUri,
+                                          final String predicateUri, final String objectUri, final boolean present) {
+        // Verify absence of member triple in response body
+        final org.apache.jena.rdf.model.Statement tripleMember = ResourceFactory.createStatement(
+            ResourceFactory.createResource(subjectUri),
+            ResourceFactory.createProperty(predicateUri),
+            ResourceFactory.createResource(objectUri));
+        return new TripleMatcher(tripleMember, present).matches(response.getBody().asString());
+    }
+
+    /**
+     * 3.1.2-A
+     */
+    @Test(groups = {"MUST"})
+    public void ldpDirectContainerMustAllowMembershipConstantURIToBeSet() {
+        setupTest("3.1.2-A",
+                  "Implementations " +
+                  "MUST allow the membership constant URI to be set via the " +
+                  "ldp:membershipResource property of the content RDF on container creation.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String membershipResource = getLocation(doPost(uri));
+
+        final String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> .\n"
+                            + "<> ldp:membershipResource <" + membershipResource + "> ;";
+        final Response directContainer = createDirectContainer(uri, body);
+        final String directContainerResource = getLocation(directContainer);
+        confirmPresenceOrAbsenceOfTripleInResponse(doGet(directContainerResource), directContainerResource,
+                                                   LDP_MEMBERSHIP_RESOURCE_PREDICATE, membershipResource, true);
+    }
+
+    /**
+     * 3.1.2-B
+     */
+    @Test(groups = {"MUST"})
+    public void ldpDirectContainerMustSetLdpMembershipResourceByDefault() {
+        setupTest("3.1.2-B",
+                  "Implementations MUST set the ldp:membershipResource by default when" +
+                  " not specified on creation.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+        final String body = "";
+        final Response directContainer = createDirectContainer(uri, body);
+        final String directContainerResource = getLocation(directContainer);
+        final String responseBody = doGet(getLocation(directContainer)).getBody().asString();
+        try (CloseableDataset dataset = parseTriples(IOUtils.toInputStream(responseBody))) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(ANY, createURI(directContainerResource),
+                                      createURI(LDP_MEMBERSHIP_RESOURCE_PREDICATE), ANY));
+        }
+    }
+
+    /**
+     * 3.1.2-C
+     */
+    @Test(groups = {"SHOULD"})
+    public void ldpDirectContainerMustSetLdpMembershipResourceValueToLDPCByDefault() {
+        setupTest("3.1.2-C",
+                  "Implementations SHOULD set the ldp:membershipResource to the LDPC " +
+                  " by default when not specified on creation.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+        final String membershipResource = getLocation(doPost(uri));
+        final String body = "";
+        final Response directContainer = createDirectContainer(uri, body);
+        final String directContainerResource = getLocation(directContainer);
+        confirmPresenceOrAbsenceOfTripleInResponse(doGet(directContainerResource), directContainerResource,
+                                                   LDP_MEMBERSHIP_RESOURCE_PREDICATE, membershipResource, true);
+    }
+
+    private CloseableDataset parseTriples(final InputStream content) {
+        final Model model = createDefaultModel();
+        model.read(content, "", "text/turtle");
+        return new CloseableDataset(model);
+    }
+
+    private class CloseableDataset extends DatasetImpl implements AutoCloseable {
+        private CloseableDataset(final Model model) {
+            super(model);
+        }
+    }
+
+    /**
+     * 3.1.2-D
+     */
+    @Test(groups = {"MAY"})
+    public void ldpDirectContainerMayAllowLdpMembershipToBeUpdatedByPut() {
+        setupTest("3.1.2-D",
+                  "Implementations may allow the membership constant URI to be updated by " +
+                  "subsequent PUT requests that change the ldp:membershipResource " +
+                  "property of the resource content.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String membershipResource1 = getLocation(doPost(uri));
+        final String membershipResource2 = getLocation(doPost(uri));
+
+        final Response response = createDirectContainer(uri, DIRECT_CONTAINER_BODY
+            .replace("%membershipResource%", membershipResource1));
+        final String directContainerResource = getLocation(response);
+        final String body = doGet(directContainerResource).getBody().asString();
+        final String newBody = body.replace(membershipResource1, membershipResource2);
+        final Response updateResponse =
+            doPutUnverified(directContainerResource, new Headers(new Header("Content-Type", "text/turtle")), newBody);
+        if (clientErrorRange().matches(updateResponse.statusCode())) {
+            throw new SkipException("This implementation does not support PUT updates on ldp:membershipResource");
+        }
+
+        final Response getUpdatedResource = doGet(directContainerResource);
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                   LDP_MEMBERSHIP_RESOURCE_PREDICATE, membershipResource2, true);
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                                   LDP_MEMBERSHIP_RESOURCE_PREDICATE, membershipResource1, false);
+    }
+
+    /**
+     * 3.1.2-E
+     */
+    @Test(groups = {"MAY"})
+    public void ldpDirectContainerMayAllowLdpMembershipToBeUpdatedByPatch() {
+        setupTest("3.1.2-E",
+                  "Implementations may allow the membership constant URI to be updated by " +
+                  "subsequent PATCH requests that change the ldp:membershipResource " +
+                  "property of the resource content.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String membershipResource1 = getLocation(doPost(uri));
+        final String membershipResource2 = getLocation(doPost(uri));
+
+        final Response response = createDirectContainer(uri, DIRECT_CONTAINER_BODY
+            .replace("%membershipResource%", membershipResource1));
+        final String directContainerResource = getLocation(response);
+
+        final String sparqlUpdate =
+            "DELETE { <> <" + LDP_MEMBERSHIP_RESOURCE_PREDICATE + "> <" + membershipResource1 + ">  } \n" +
+            "INSERT { <> <" + LDP_MEMBERSHIP_RESOURCE_PREDICATE + "> <" + membershipResource2 + ">  } \n" +
+            "WHERE {}";
+
+        final Response updateResponse =
+            doPatchUnverified(directContainerResource,
+                              new Headers(new Header("Content-Type", "application/sparql-update")),
+                              sparqlUpdate);
+        if (clientErrorRange().matches(updateResponse.statusCode())) {
+            throw new SkipException("This implementation does not support PATCH updates on ldp:membershipResource");
+        }
+
+        final Response getUpdatedResource = doGet(directContainerResource);
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                   LDP_MEMBERSHIP_RESOURCE_PREDICATE, membershipResource2, true);
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                                   LDP_MEMBERSHIP_RESOURCE_PREDICATE, membershipResource1, false);
+    }
+
+    /**
+     * 3.1.2-G-1
+     */
+    @Test(groups = {"MUST"})
+    public void ldpDirectContainerMustAllowHasMemberRelationPredicateToBeSetOnCreate() {
+        setupTest("3.1.2-G-1",
+                  "Implementations must allow the membership predicate  to be set " +
+                  "via either the ldp:hasMemberRelation or ldp:isMemberOfRelation property " +
+                  "of the content RDF on container creation, or otherwise default to an " +
+                  "implementation defined value. Implementations should use the default <> " +
+                  "ldp:hasMemberRelation ldp:member",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String hasMemberPredicate = "http://example.org/ldp/member";
+        final String body = "<> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + hasMemberPredicate + "> ;";
+        final Response directContainer = createDirectContainer(uri, body);
+        final String directContainerResource = getLocation(directContainer);
+        confirmPresenceOrAbsenceOfTripleInResponse(doGet(directContainerResource), directContainerResource,
+                                                   LDP_HAS_MEMBER_RELATION_PREDICATE, hasMemberPredicate, true);
+    }
+
+    /**
+     * 3.1.2-G-2
+     */
+    @Test(groups = {"MUST"})
+    public void ldpDirectContainerMustAllowIsMemberOfRelationPredicateToBeSetOnCreate() {
+        setupTest("3.1.2-G-2",
+                  "Implementations must allow the membership predicate  to be set " +
+                  "via ldp:isMemberOfRelation property " +
+                  "of the content RDF on container creation, or otherwise default to an " +
+                  "implementation defined value. Implementations should use the default <> " +
+                  "ldp:hasMemberRelation ldp:member",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String isMemberPredicate = "http://example.org/ldp/isMemberOf";
+        final String body = "<> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberPredicate + "> ;";
+        final Response directContainer = createDirectContainer(uri, body);
+        final String directContainerResource = getLocation(directContainer);
+        confirmPresenceOrAbsenceOfTripleInResponse(doGet(directContainerResource), directContainerResource,
+                                                   LDP_IS_MEMBER_OF_RELATION_PREDICATE, isMemberPredicate, true);
+    }
+
+    /**
+     * 3.1.2-H
+     */
+    @Test(groups = {"MUST"})
+    public void ldpDirectContainerMustAllowMembershipPredicateToBeSetByDefault() {
+        setupTest("3.1.2-H",
+                  "Implementations must allow the membership predicate  to be set by " +
+                  "default to an implementation defined value. ",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String body = "";
+        final Response directContainer = createDirectContainer(uri, body);
+        final String directContainerResource = getLocation(directContainer);
+        final String responseBody = doGet(getLocation(directContainer)).getBody().asString();
+        try (CloseableDataset dataset = parseTriples(IOUtils.toInputStream(responseBody))) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            if (!graph
+                .contains(ANY, createURI(directContainerResource), createURI(LDP_HAS_MEMBER_RELATION_PREDICATE), ANY) &&
+                !graph.contains(ANY, createURI(directContainerResource), createURI(LDP_IS_MEMBER_OF_RELATION_PREDICATE),
+                                ANY)) {
+                fail("Neither the " + LDP_HAS_MEMBER_RELATION_PREDICATE + " nor the " +
+                     LDP_IS_MEMBER_OF_RELATION_PREDICATE + " predicate found");
+            }
+        }
+    }
+
+    /**
+     * 3.1.2-I
+     */
+    @Test(groups = {"SHOULD"})
+    public void ldpDirectContainerShouldUseLdpMemberByDefault() {
+        setupTest("3.1.2-I",
+                  "Implementations should use the default <> ldp:hasMemberRelation ldp:member",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String body = "";
+        final Response directContainer = createDirectContainer(uri, body);
+        final String directContainerResource = getLocation(directContainer);
+        final Response response = doGet(getLocation(directContainer));
+        confirmPresenceOrAbsenceOfTripleInResponse(response, directContainerResource, LDP_HAS_MEMBER_RELATION_PREDICATE,
+                                                   LDP_MEMBER, true);
+    }
+
+    /**
+     * 3.1.2-J
+     */
+    @Test(groups = {"MAY"})
+    public void ldpDirectContainerMayAllowLdpHasMemberRelationPredicateToBeUpdatedByPut() {
+        setupTest("3.1.2-J",
+                  "Implementations may allow the membership predicate to be updated by " +
+                  "subsequent PUT requests that change the ldp:hasMemberRelation " +
+                  "property of the resource content.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String hasMemberPredicate1 = "http://example.org/ldp/member1";
+        final String hasMemberPredicate2 = "http://example.org/ldp/member2";
+
+        final String requestBody = "<> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + hasMemberPredicate1 + "> ;\n";
+
+        final Response response = createDirectContainer(uri, requestBody);
+        final String directContainerResource = getLocation(response);
+        final String body = doGet(directContainerResource).getBody().asString();
+        final String newBody = body.replace(hasMemberPredicate1, hasMemberPredicate2);
+        final Response updateResponse =
+            doPutUnverified(directContainerResource, new Headers(new Header("Content-Type", "text/turtle")), newBody);
+        if (clientErrorRange().matches(updateResponse.statusCode())) {
+            throw new SkipException(
+                "This implementation does not support PUT updates on " + LDP_HAS_MEMBER_RELATION_PREDICATE);
+        }
+
+        final Response getUpdatedResource = doGet(directContainerResource);
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                   LDP_HAS_MEMBER_RELATION_PREDICATE, hasMemberPredicate2, true);
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                                   LDP_HAS_MEMBER_RELATION_PREDICATE, hasMemberPredicate1, false);
+    }
+
+    /**
+     * 3.1.2-K
+     */
+    @Test(groups = {"MAY"})
+    public void ldpDirectContainerMayAllowLdpHasMemberRelationToBeUpdatedByPatch() {
+        setupTest("3.1.2-K",
+                  "Implementations may allow the membership predicate to be updated by " +
+                  "subsequent PATCH requests that change the ldp:hasMemberRelation " +
+                  "property of the resource content.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String hasMemberPredicate = "http://example.org/ldp/member";
+        final String requestBody = "<> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + LDP_MEMBER + "> ;\n";
+        final Response response = createDirectContainer(uri, requestBody);
+        final String directContainerResource = getLocation(response);
+
+        final String sparqlUpdate =
+            "DELETE { <> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + LDP_MEMBER + ">  } \n" +
+            "INSERT { <> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + hasMemberPredicate + ">  } \n" +
+            "WHERE {}";
+
+        final Response updateResponse =
+            doPatchUnverified(directContainerResource,
+                              new Headers(new Header("Content-Type", "application/sparql-update")),
+                              sparqlUpdate);
+        if (clientErrorRange().matches(updateResponse.statusCode())) {
+            throw new SkipException(
+                "This implementation does not support PATCH updates on " + LDP_HAS_MEMBER_RELATION_PREDICATE);
+        }
+
+        final Response getUpdatedResource = doGet(directContainerResource);
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                   LDP_HAS_MEMBER_RELATION_PREDICATE, hasMemberPredicate, true);
+
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                                   LDP_HAS_MEMBER_RELATION_PREDICATE, LDP_MEMBER, false);
+
+    }
+
+    /**
+     * 3.1.2-L
+     */
+    @Test(groups = {"MAY"})
+    public void ldpDirectContainerMayAllowLdpIsMemberRelationPredicateToBeUpdatedByPut() {
+        setupTest("3.1.2-L",
+                  "Implementations may allow the membership predicate to be updated by " +
+                  "subsequent PUT requests that change the ldp:isMemberOfRelation property of " +
+                  "the resource content.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String isMemberOfPredicate1 = "http://example.org/ldp/isMemberOf1";
+        final String isMemberOfPredicate2 = "http://example.org/ldp/isMemberOf2";
+
+        final String requestBody =
+            "<> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberOfPredicate1 + "> ;\n";
+
+        final Response response = createDirectContainer(uri, requestBody);
+        final String directContainerResource = getLocation(response);
+        final String body = doGet(directContainerResource).getBody().asString();
+
+        final String newBody = body.replace(isMemberOfPredicate1, isMemberOfPredicate2);
+        final Response updateResponse =
+            doPutUnverified(directContainerResource, new Headers(new Header("Content-Type", "text/turtle")), newBody);
+        if (clientErrorRange().matches(updateResponse.statusCode())) {
+            throw new SkipException(
+                "This implementation does not support PUT updates on " + LDP_IS_MEMBER_OF_RELATION_PREDICATE);
+        }
+
+        final Response getUpdatedResource = doGet(directContainerResource);
+        if (!testForPresenceOfTrip(getUpdatedResource, directContainerResource,
+                                   LDP_IS_MEMBER_OF_RELATION_PREDICATE, isMemberOfPredicate2, true)) {
+            throw new SkipException(
+                "This implementation does not support PUT updates on " + LDP_IS_MEMBER_OF_RELATION_PREDICATE);
+        }
+
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                                   LDP_IS_MEMBER_OF_RELATION_PREDICATE, isMemberOfPredicate1, false);
+
+    }
+
+    /**
+     * 3.1.2-M
+     */
+    @Test(groups = {"MAY"})
+    public void ldpDirectContainerMayAllowLdpIsMemberRelationToBeUpdatedByPatch() {
+        setupTest("3.1.2-M",
+                  "Implementations may allow the membership predicate to be updated by " +
+                  "subsequent PATCH requests that change the ldp:isMemberOfRelation " +
+                  "property of the resource content.",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  ps);
+
+        //throw skip exception if direct containers not supported
+        skipIfDirectContainersNotSupported();
+
+        final String isMemberOfPredicate1 = "http://example.org/ldp/isMemberOf1";
+        final String isMemberOfPredicate2 = "http://example.org/ldp/isMemberOf2";
+        final String requestBody =
+            "<> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberOfPredicate1 + "> ;\n";
+        final Response response = createDirectContainer(uri, requestBody);
+        final String directContainerResource = getLocation(response);
+
+        final String sparqlUpdate =
+            "DELETE { <> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberOfPredicate1 + ">  } \n" +
+            "INSERT { <> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberOfPredicate2 + ">  } \n" +
+            "WHERE {}";
+
+        final Response updateResponse =
+            doPatchUnverified(directContainerResource,
+                              new Headers(new Header("Content-Type", "application/sparql-update")),
+                              sparqlUpdate);
+        if (clientErrorRange().matches(updateResponse.statusCode())) {
+            throw new SkipException(
+                "This implementation does not support PATCH updates on " + LDP_IS_MEMBER_OF_RELATION_PREDICATE);
+        }
+
+        final Response getUpdatedResource = doGet(directContainerResource);
+        if (!testForPresenceOfTrip(getUpdatedResource, directContainerResource,
+                                   LDP_IS_MEMBER_OF_RELATION_PREDICATE, isMemberOfPredicate2, true)) {
+            throw new SkipException(
+                "This implementation does not support PATCH updates on " + LDP_IS_MEMBER_OF_RELATION_PREDICATE);
+        }
+
+        confirmPresenceOrAbsenceOfTripleInResponse(getUpdatedResource, directContainerResource,
+                                                   LDP_IS_MEMBER_OF_RELATION_PREDICATE, isMemberOfPredicate1, false);
+
+    }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
@@ -46,11 +46,14 @@ import java.io.InputStream;
  */
 public class Container extends AbstractTest {
 
-    public static final String LDP_CONTAINS_PREDICATE = "http://www.w3.org/ns/ldp#contains";
-    public static final String LDP_MEMBERSHIP_RESOURCE_PREDICATE = "http://www.w3.org/ns/ldp#membershipResource";
-    public static final String LDP_HAS_MEMBER_RELATION_PREDICATE = "http://www.w3.org/ns/ldp#hasMemberRelation";
-    public static final String LDP_IS_MEMBER_OF_RELATION_PREDICATE = "http://www.w3.org/ns/ldp#isMemberOfRelation";
-    public static final String LDP_MEMBER = "http://www.w3.org/ns/ldp#member";
+    private static final String LDP_CONTAINS_PREDICATE = "http://www.w3.org/ns/ldp#contains";
+    private static final String LDP_MEMBERSHIP_RESOURCE_PREDICATE = "http://www.w3.org/ns/ldp#membershipResource";
+    private static final String LDP_HAS_MEMBER_RELATION_PREDICATE = "http://www.w3.org/ns/ldp#hasMemberRelation";
+    private static final String LDP_IS_MEMBER_OF_RELATION_PREDICATE = "http://www.w3.org/ns/ldp#isMemberOfRelation";
+    private static final String LDP_MEMBER = "http://www.w3.org/ns/ldp#member";
+
+    private Boolean directContainersSupported = null;
+    private Boolean indirectContainersSupported = null;
 
     /**
      * 3.1.1-A-1
@@ -88,17 +91,27 @@ public class Container extends AbstractTest {
     }
 
     private void skipIfDirectContainersNotSupported() {
-        final String membershipResource = getLocation(doPost(uri));
-        if (clientErrorRange().matches(createDirectContainerUnverified(uri, DIRECT_CONTAINER_BODY
-            .replace("%membershipResource%", membershipResource)).getStatusCode())) {
+        if (directContainersSupported == null) {
+            final String membershipResource = getLocation(doPost(uri));
+            directContainersSupported =
+                (successRange().matches(createDirectContainerUnverified(uri, DIRECT_CONTAINER_BODY
+                    .replace("%membershipResource%", membershipResource)).getStatusCode()));
+        }
+
+        if (!directContainersSupported) {
             throw new SkipException("This implementation does not support DirectContainers");
         }
     }
 
     private void skipIfIndirectContainersNotSupported() {
-        final String membershipResource = getLocation(doPost(uri));
-        if (clientErrorRange().matches(createIndirectContainerUnverified(uri, INDIRECT_CONTAINER_BODY
-            .replace("%membershipResource%", membershipResource)).getStatusCode())) {
+        if (indirectContainersSupported == null) {
+            final String membershipResource = getLocation(doPost(uri));
+            indirectContainersSupported =
+                (successRange().matches(createIndirectContainerUnverified(uri, INDIRECT_CONTAINER_BODY
+                    .replace("%membershipResource%", membershipResource)).getStatusCode()));
+        }
+
+        if (!indirectContainersSupported) {
             throw new SkipException("This implementation does not support IndirectContainers");
         }
     }
@@ -301,7 +314,7 @@ public class Container extends AbstractTest {
                   "Implementations " +
                   "MUST allow the membership constant URI to be set via the " +
                   "ldp:membershipResource property of the content RDF on container creation.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -324,7 +337,7 @@ public class Container extends AbstractTest {
         setupTest("3.1.2-B",
                   "Implementations MUST set the ldp:membershipResource by default when" +
                   " not specified on creation.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -347,7 +360,7 @@ public class Container extends AbstractTest {
         setupTest("3.1.2-C",
                   "Implementations SHOULD set the ldp:membershipResource to the LDPC " +
                   " by default when not specified on creation.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -380,7 +393,7 @@ public class Container extends AbstractTest {
                   "Implementations may allow the membership constant URI to be updated by " +
                   "subsequent PUT requests that change the ldp:membershipResource " +
                   "property of the resource content.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
 
         //throw skip exception if direct containers not supported
@@ -416,7 +429,7 @@ public class Container extends AbstractTest {
                   "Implementations may allow the membership constant URI to be updated by " +
                   "subsequent PATCH requests that change the ldp:membershipResource " +
                   "property of the resource content.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -459,7 +472,7 @@ public class Container extends AbstractTest {
                   "of the content RDF on container creation, or otherwise default to an " +
                   "implementation defined value. Implementations should use the default <> " +
                   "ldp:hasMemberRelation ldp:member",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -483,7 +496,7 @@ public class Container extends AbstractTest {
                   "of the content RDF on container creation, or otherwise default to an " +
                   "implementation defined value. Implementations should use the default <> " +
                   "ldp:hasMemberRelation ldp:member",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -504,7 +517,7 @@ public class Container extends AbstractTest {
         setupTest("3.1.2-H",
                   "Implementations must allow the membership predicate  to be set by " +
                   "default to an implementation defined value. ",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -532,7 +545,7 @@ public class Container extends AbstractTest {
     public void ldpDirectContainerShouldUseLdpMemberByDefault() {
         setupTest("3.1.2-I",
                   "Implementations should use the default <> ldp:hasMemberRelation ldp:member",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -554,7 +567,7 @@ public class Container extends AbstractTest {
                   "Implementations may allow the membership predicate to be updated by " +
                   "subsequent PUT requests that change the ldp:hasMemberRelation " +
                   "property of the resource content.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -591,7 +604,7 @@ public class Container extends AbstractTest {
                   "Implementations may allow the membership predicate to be updated by " +
                   "subsequent PATCH requests that change the ldp:hasMemberRelation " +
                   "property of the resource content.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
@@ -633,7 +646,7 @@ public class Container extends AbstractTest {
                   "Implementations may allow the membership predicate to be updated by " +
                   "subsequent PUT requests that change the ldp:isMemberOfRelation property of " +
                   "the resource content.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
 
         //throw skip exception if direct containers not supported
@@ -678,7 +691,7 @@ public class Container extends AbstractTest {
                   "Implementations may allow the membership predicate to be updated by " +
                   "subsequent PATCH requests that change the ldp:isMemberOfRelation " +
                   "property of the resource content.",
-                  "https://fcrepo.github.io/fcrepo-specification/#ldpc",
+                  "https://fcrepo.github.io/fcrepo-specification/#ldpdc",
                   ps);
 
         //throw skip exception if direct containers not supported

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Ldpnr.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Ldpnr.java
@@ -35,11 +35,11 @@ import org.testng.annotations.Test;
 public class Ldpnr extends AbstractTest {
 
     /**
-     * 3.1.2.-A
+     * 3.1.4-A
      */
     @Test(groups = {"SHOULD"})
     public void ldpnrCreationLinkType() {
-        final TestInfo info = setupTest("3.1.2-A",
+        final TestInfo info = setupTest("3.1.4-A",
                                         "If, in a successful resource creation request, a Link: rel=\"type\" request " +
                                         "header specifies"
                                         +
@@ -93,11 +93,11 @@ public class Ldpnr extends AbstractTest {
     }
 
     /**
-     * 3.1.2.-B
+     * 3.1.4-B
      */
     @Test(groups = {"SHOULD"})
     public void ldpnrCreationWrongLinkType() {
-        final TestInfo info = setupTest("3.1.2-B",
+        final TestInfo info = setupTest("3.1.4-B",
                                         "If, in a successful resource creation request, a Link: rel=\"type\" request " +
                                         "header specifies"
                                         +


### PR DESCRIPTION
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/276