### PR TITLE
Adds support for optionally specifying the name and version of the Fe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ $ java -jar target/testSuite-1.0-SNAPSHOT-shaded.jar --rooturl http://localhost:
 * `site-name` (optional) The above yaml file can contain multiple configurations, this chooses one. Defaults to "default"
 * `constraint-error-generator` (optional)  A file containing a SPARQL query that will trigger a constraint error. If no file is specified, the test suite will use a default constraint error generating test.
 * `auth-class` (optional) The class name of an implementation of the org.fcrepo.spec.testsuite.authn.Authenticator interface.
+* `implementation-name` (optional) The name of the implementation being tested.
+* `implementation-version` (optional) The version of the implementation being tested.
 
 ### Authenticators
 The Fedora Specification does not have anything to say about how requests are authenticated by implementations.  Therefore it is necessary for each implementation to perform

--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -21,6 +21,8 @@ import static org.fcrepo.spec.testsuite.TestParameters.AUTHENTICATOR_CLASS_PARAM
 import static org.fcrepo.spec.testsuite.TestParameters.BROKER_URL_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.CONFIG_FILE_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.CONSTRAINT_ERROR_GENERATOR_PARAM;
+import static org.fcrepo.spec.testsuite.TestParameters.IMPLEMENTATION_NAME_PARAM;
+import static org.fcrepo.spec.testsuite.TestParameters.IMPLEMENTATION_VERSION_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.PERMISSIONLESS_USER_AUTH_HEADER;
 import static org.fcrepo.spec.testsuite.TestParameters.PERMISSIONLESS_USER_PASSWORD_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.PERMISSIONLESS_USER_WEBID_PARAM;
@@ -89,6 +91,8 @@ public class App {
         configArgs.put(QUEUE_NAME_PARAM, false);
         configArgs.put(TOPIC_NAME_PARAM, false);
         configArgs.put(CONSTRAINT_ERROR_GENERATOR_PARAM, false);
+        configArgs.put(IMPLEMENTATION_NAME_PARAM, false);
+        configArgs.put(IMPLEMENTATION_VERSION_PARAM, false);
     }
 
     /**
@@ -140,6 +144,11 @@ public class App {
                                   "the 'authenticators' directory, it will be discovered and used automatically.  " +
                                   "In other words, if you have only one implementation you don't need to use this " +
                                   "optional parameter."));
+        options.addOption(
+            new Option("w", IMPLEMENTATION_NAME_PARAM, true, "The name of the Fedora implementation being tested."));
+        options.addOption(
+            new Option("v", IMPLEMENTATION_VERSION_PARAM, true,
+                       "The version of the Fedora implementation being tested."));
 
         final CommandLineParser parser = new BasicParser();
         final CommandLine cmd;
@@ -172,6 +181,16 @@ public class App {
                 // Fill in missing parts with blanks
                 params.put(opt, "");
             }
+        }
+
+        if (isNullOrEmpty(params.get(IMPLEMENTATION_NAME_PARAM))) {
+            params.put(IMPLEMENTATION_NAME_PARAM,
+                       "{ implementation name: please use --" + IMPLEMENTATION_NAME_PARAM + " to specify }");
+        }
+
+        if (isNullOrEmpty(params.get(IMPLEMENTATION_VERSION_PARAM))) {
+            params.put(IMPLEMENTATION_VERSION_PARAM,
+                       "{ implementation version: please use --" + IMPLEMENTATION_VERSION_PARAM + " to specify}");
         }
 
         TestParameters.initialize(params);

--- a/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
@@ -197,7 +197,7 @@ public class TestParameters {
 
     /**
      * Get the name of the implementation under test.
-     * @return the name of the implemenation
+     * @return the name of the implementation
      */
     public String getImplementationName() {
         return params.get(IMPLEMENTATION_NAME_PARAM);
@@ -205,7 +205,7 @@ public class TestParameters {
 
     /**
      * Get the version of the implementation under test.
-     * @return the version of the implemenation
+     * @return the version of the implementation
      */
     public String getImplementationVersion() {
         return params.get(IMPLEMENTATION_VERSION_PARAM);

--- a/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
@@ -56,6 +56,10 @@ public class TestParameters {
 
     public final static String AUTHENTICATOR_CLASS_PARAM = "auth-class";
 
+    public final static String IMPLEMENTATION_NAME_PARAM = "implementation-name";
+
+    public final static String IMPLEMENTATION_VERSION_PARAM = "implementation-version";
+
     private static TestParameters instance;
 
     private Map<String, String> params = null;
@@ -189,5 +193,21 @@ public class TestParameters {
      */
     public String getConstraintErrorGenerator() {
         return params.get(CONSTRAINT_ERROR_GENERATOR_PARAM);
+    }
+
+    /**
+     * Get the name of the implementation under test.
+     * @return the name of the implemenation
+     */
+    public String getImplementationName() {
+        return params.get(IMPLEMENTATION_NAME_PARAM);
+    }
+
+    /**
+     * Get the version of the implementation under test.
+     * @return the version of the implemenation
+     */
+    public String getImplementationVersion() {
+        return params.get(IMPLEMENTATION_VERSION_PARAM);
     }
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
+import org.fcrepo.spec.testsuite.TestParameters;
 import org.fcrepo.spec.testsuite.TestSuiteGlobals;
 import org.rendersnake.HtmlCanvas;
 import org.rendersnake.StringResource;
@@ -72,6 +73,9 @@ public class HtmlReporter implements IReporter {
                 html.title().content("Fedora API Test Suite Report")._head()
                     .body();
                 html.h1().content("Fedora API Test Suite Summary");
+
+                html.h2().content("for " + TestParameters.get().getImplementationName() + " " +
+                                  TestParameters.get().getImplementationVersion());
 
                 // Getting the results for the said suite
                 final Map<String, ISuiteResult> suiteResults = suite.getResults();

--- a/src/main/resources/reportStyle.css
+++ b/src/main/resources/reportStyle.css
@@ -1,6 +1,6 @@
 @CHARSET "ISO-8859-1";
 
-h1 {
+h1, h2 {
     text-align: center
 }
 


### PR DESCRIPTION
…dora implementation under test.

Use --implementation-name and --implementation-version command-line params (or -w and -v respectively)
Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/267