### PR TITLE
Adds the --root-controller-user-name and --permissionless-user-name w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ $ java -jar target/testSuite-1.0-SNAPSHOT-shaded.jar --rooturl http://localhost:
 
 ## Options
 * `rooturl` The repository base URL, e.g., `http://localhost:8080/rest/`
-* `root-controller-user-webid` An user with admin access to the repository.
-* `root-controller-user-password` The admin user's password.
+* `root-controller-user-webid` A URI representing the WebID of a user with read, write, and control permissions on root container (corresponding with either root-controller-user-name and root-controller-user-password, or root-controller-user-auth-header-value).
+* `root-controller-user-name` Username of user associated with root-controller-user-webid
+* `root-controller-user-password` Password of user associated with root-controller-user-webid 
 * `root-controller-user-auth-header-value` "Authorization" header value for a user with read, write, and control.  When present, this value will be added to the request effectively overriding Authenticator implementations, custom or default, found in the classpath.
-* `permissionless-user-webid` The username to connect to the repository with
-* `permissionless-user-password` The password to connect to the repository with
+* `permissionless-user-webid` A URI representing the WebID of a user with no permissions (corresponding with either permissionless-user-name and permissionless-user-password, or permissionless-user-auth-header-value). 
+* `permissionless-user-name` Username of user associated with the permissionless-user-webid
+* `permissionless-user-password` Password of user associated with permissionless-user-webid
 * `permissionless-user-auth-header-value` "Authorization" header value for a user with no preset permissions.  When present, this value will be added to the request, effectively overriding Authenticator implementations, custom or default, found in the classpath.
 * `testngxml` (optional) The custom testng.xml configuration ([documentation](http://testng.org/doc/documentation-main.html#testng-xml))
   * See example [testng.xml](https://github.com/fcrepo/Fedora-API-Test-Suite/tree/master/src/main/resources/testng.xml)

--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -22,10 +22,12 @@ import static org.fcrepo.spec.testsuite.TestParameters.BROKER_URL_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.CONFIG_FILE_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.CONSTRAINT_ERROR_GENERATOR_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.PERMISSIONLESS_USER_AUTH_HEADER;
+import static org.fcrepo.spec.testsuite.TestParameters.PERMISSIONLESS_USER_NAME_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.PERMISSIONLESS_USER_PASSWORD_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.PERMISSIONLESS_USER_WEBID_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.QUEUE_NAME_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.ROOT_CONTROLLER_USER_AUTH_HEADER;
+import static org.fcrepo.spec.testsuite.TestParameters.ROOT_CONTROLLER_USER_NAME_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.ROOT_CONTROLLER_USER_PASSWORD_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.ROOT_CONTROLLER_USER_WEBID_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.ROOT_URL_PARAM;
@@ -78,9 +80,11 @@ public class App {
     static {
         configArgs.put(ROOT_URL_PARAM, true);
         configArgs.put(PERMISSIONLESS_USER_WEBID_PARAM, true);
+        configArgs.put(PERMISSIONLESS_USER_NAME_PARAM, false);
         configArgs.put(PERMISSIONLESS_USER_PASSWORD_PARAM, false);
         configArgs.put(PERMISSIONLESS_USER_AUTH_HEADER, false);
         configArgs.put(ROOT_CONTROLLER_USER_WEBID_PARAM, true);
+        configArgs.put(ROOT_CONTROLLER_USER_NAME_PARAM, false);
         configArgs.put(ROOT_CONTROLLER_USER_PASSWORD_PARAM, false);
         configArgs.put(ROOT_CONTROLLER_USER_AUTH_HEADER, false);
         configArgs.put(TESTNGXML_PARAM, false);
@@ -100,27 +104,36 @@ public class App {
         final Options options = new Options();
         options.addOption(new Option("b", ROOT_URL_PARAM, true, "The root URL of the repository"));
         options.addOption(new Option("u", PERMISSIONLESS_USER_WEBID_PARAM, true,
-                                     "A URI representing the WebID of a user with no permissions."));
+                                     "A URI representing the WebID of a user with no permissions  (corresponding with" +
+                                     " either " + PERMISSIONLESS_USER_NAME_PARAM + " and " +
+                                     PERMISSIONLESS_USER_PASSWORD_PARAM + ", or " +
+                                     PERMISSIONLESS_USER_AUTH_HEADER + ")."));
         options.addOption(
-            new Option("p", PERMISSIONLESS_USER_PASSWORD_PARAM, true, "Password of user with basic user role"));
+            new Option("p", PERMISSIONLESS_USER_PASSWORD_PARAM, true,
+                       "Password associated with " + PERMISSIONLESS_USER_NAME_PARAM));
         options.addOption(new Option("a", ROOT_CONTROLLER_USER_WEBID_PARAM, true,
                                      "A URI representing the WebID of a user with read, write, and control" +
-                                     " permissions on root container."));
+                                     " permissions on root container  (corresponding with either " +
+                                     ROOT_CONTROLLER_USER_NAME_PARAM + " and " + ROOT_CONTROLLER_USER_PASSWORD_PARAM +
+                                     ", or " +
+                                     ROOT_CONTROLLER_USER_AUTH_HEADER + ")."));
         options.addOption(
-            new Option("s", ROOT_CONTROLLER_USER_PASSWORD_PARAM, true, "Password of user with admin role"));
-
+            new Option("A", ROOT_CONTROLLER_USER_NAME_PARAM, true,
+                       "Username associated with " + ROOT_CONTROLLER_USER_WEBID_PARAM));
+        options.addOption(
+            new Option("s", ROOT_CONTROLLER_USER_PASSWORD_PARAM, true,
+                       "Password of user associated with " + ROOT_CONTROLLER_USER_WEBID_PARAM));
         options.addOption(new Option("R", ROOT_CONTROLLER_USER_AUTH_HEADER, true,
                                      "\"Authorization\" header value for a user with read, write, and control. " +
                                      "When present, this value will be added to the request effectively " +
                                      "overriding Authenticator implementations, custom or default, found in the " +
                                      "classpath."));
-
         options.addOption(new Option("P", PERMISSIONLESS_USER_AUTH_HEADER, true,
                                      "\"Authorization\" header value for a user with no permissions. " +
                                      "When present, this value will be added to the request effectively " +
                                      "overriding Authenticator implementations, custom or default, found in the " +
                                      "classpath."));
-        options.addOption( new Option("x", TESTNGXML_PARAM, true, "TestNG XML file"));
+        options.addOption(new Option("x", TESTNGXML_PARAM, true, "TestNG XML file"));
         options.addOption(new Option("r", REQUIREMENTS_PARAM, true,
                                      "Requirement levels. One or more of the following, " +
                                      "separated by ',': [ALL|MUST|SHOULD|MAY]"));

--- a/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
@@ -34,6 +34,8 @@ public class TestParameters {
 
     public final static String PERMISSIONLESS_USER_WEBID_PARAM = "permissionless-user-webid";
 
+    public final static String PERMISSIONLESS_USER_NAME_PARAM = "permissionless-user-name";
+
     public final static String PERMISSIONLESS_USER_PASSWORD_PARAM = "permissionless-user-password";
 
     public final static String PERMISSIONLESS_USER_AUTH_HEADER = "permissionless-user-auth-header-value";
@@ -41,6 +43,8 @@ public class TestParameters {
     public final static String ROOT_CONTROLLER_USER_WEBID_PARAM = "root-controller-user-webid";
 
     public final static String ROOT_CONTROLLER_USER_AUTH_HEADER = "root-controller-user-auth-header-value";
+
+    public final static String ROOT_CONTROLLER_USER_NAME_PARAM = "root-controller-user-name";
 
     public final static String ROOT_CONTROLLER_USER_PASSWORD_PARAM = "root-controller-user-password";
 
@@ -103,6 +107,14 @@ public class TestParameters {
     }
 
     /**
+     * The root controller username
+     * @return the username
+     */
+    public String getRootControllerUsername() {
+        return params.get(ROOT_CONTROLLER_USER_NAME_PARAM);
+    }
+
+    /**
      * The root controller user password
      * @return the password
      */
@@ -125,6 +137,14 @@ public class TestParameters {
 
     public String getPermissionlessUserWebId() {
         return params.get(PERMISSIONLESS_USER_WEBID_PARAM);
+    }
+
+    /**
+     * The permissionless username
+     * @return the username
+     */
+    public String getPermissionlessUsername() {
+        return params.get(PERMISSIONLESS_USER_NAME_PARAM);
     }
 
     /**


### PR DESCRIPTION
…hich are

now used by basic auth. Also improves the documentation of the use of these
parameters.

Resolves: https://github.com/fcrepo/Fedora-API-Test-Suite/issues/288