### PR TITLE
Re-enables WEBAC test 5.8-A-2.

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACAccessToClass.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACAccessToClass.java
@@ -63,7 +63,7 @@ public class WebACAccessToClass extends AbstractAuthzTest {
     /**
      * 5.8-A-2 - accessToClass MUST give access.
      */
-    @Test(groups = {"MUST"}, enabled = false)
+    @Test(groups = {"MUST"})
     public void accessToClassMustGiveAccessToBinary() {
         final TestInfo info = setupTest("5.8-A-2",
                                         "When an ACL includes an acl:accessToClass statement, it MUST give access to " +


### PR DESCRIPTION
This  PR should be merged once the resolution to https://jira.duraspace.org/browse/FCREPO-2977 has made it into a production release (most likely 5.0.2).