### PR TITLE
Adds an implementation-notes section to the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ $ java -jar target/testSuite-1.0-SNAPSHOT-shaded.jar --rooturl http://localhost:
 * `rooturl` The repository base URL, e.g., `http://localhost:8080/rest/`
 * `root-controller-user-webid` A URI representing the WebID of a user with read, write, and control permissions on root container (corresponding with either root-controller-user-name and root-controller-user-password, or root-controller-user-auth-header-value).
 * `root-controller-user-name` Username of user associated with root-controller-user-webid
-* `root-controller-user-password` Password of user associated with root-controller-user-webid 
+* `root-controller-user-password` Password of user associated with root-controller-user-webid
 * `root-controller-user-auth-header-value` "Authorization" header value for a user with read, write, and control.  When present, this value will be added to the request effectively overriding Authenticator implementations, custom or default, found in the classpath.
-* `permissionless-user-webid` A URI representing the WebID of a user with no permissions (corresponding with either permissionless-user-name and permissionless-user-password, or permissionless-user-auth-header-value). 
+* `permissionless-user-webid` A URI representing the WebID of a user with no permissions (corresponding with either permissionless-user-name and permissionless-user-password, or permissionless-user-auth-header-value).
 * `permissionless-user-name` Username of user associated with the permissionless-user-webid
 * `permissionless-user-password` Password of user associated with permissionless-user-webid
 * `permissionless-user-auth-header-value` "Authorization" header value for a user with no preset permissions.  When present, this value will be added to the request, effectively overriding Authenticator implementations, custom or default, found in the classpath.
@@ -46,7 +46,7 @@ org.fcrepo.spec.testsuite.authn.DefaultAuthenticator for a sample implementation
 `authenticators` located in the same directory as your testsuite jar.
 
 ### Configuration file syntax
-The configuration file is Yaml and a simple structure. The first level groups a set of configuration parameters, these parameters are key value pairs with the keys being the above options.
+The configuration file is Yaml and a simple structure. The first level groups a set of configuration parameters, these parameters are key value pairs with the keys being the above options. You may also wish to document detailed implementation-specific behavior under the `implementation-notes` key. These notes are mapped by specification section references, E.G. "3.1.1-A", and they are included in the HTML test report.
 
 ```
 default:
@@ -58,6 +58,8 @@ default:
   broker-url: tcp://127.0.0.1:61616
   topic-name: fedora
   queue-name:
+  implementation-notes:
+    3.1.1-A: Direct containers are not supported.
 ```
 
 An example with multiple configurations looks like:
@@ -72,12 +74,14 @@ default:
   broker-url: tcp://127.0.0.1:61616
   topic-name: fedora
   queue-name:
+  implementation-notes:
+    3.1.1-A: Direct containers are not supported.
 othersite:
   rooturl: http://secondserver:8080/fcrepo/rest
   root-controller-user-webid: http://example.com/totalBoss
-  root-controller-user-password: totalBoss 
+  root-controller-user-password: totalBoss
   permissionless-user-webid: http://example.com/otherperson
-  permissionless-user-password: otherpassword 
+  permissionless-user-password: otherpassword
   broker-url: tcp://overtherainbow:61616
   topic-name:
   queue-name: fedora

--- a/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
@@ -64,6 +64,8 @@ public class TestParameters {
 
     public final static String IMPLEMENTATION_VERSION_PARAM = "implementation-version";
 
+    public final static String IMPLEMENTATION_NOTES_PARAM = "implementation-notes";
+
     private static TestParameters instance;
 
     private Map<String, String> params = null;

--- a/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
+import org.fcrepo.spec.testsuite.App;
 import org.fcrepo.spec.testsuite.TestParameters;
 import org.fcrepo.spec.testsuite.TestSuiteGlobals;
 import org.rendersnake.HtmlCanvas;
@@ -220,15 +221,18 @@ public class HtmlReporter implements IReporter {
         html.tr().th().content("Specification Section");
         html.th().content("Req Level");
         html.th().content("Result");
-        html.th().content("Test Description")._tr();
+        html.th().content("Test Description");
+        html.th().content("Implementation Note")._tr();
         final Map<String, String[]> results = orderTestsResults(passedTests, skippedTests, failedTests);
 
+        final Map<String, String> implNotes = App.getImplementationNotes();
         for (String[] r : results.values()) {
             html.tr();
             html.td().a(href(r[0]).target("_blank")).write(r[3])._a()._td();
             html.td().content(r[5]);
             html.td().span(class_(r[1])).content(r[1])._td();
             html.td().content(r[2]);
+            html.td().content(implNotes.getOrDefault(r[3], ""));
             html._tr();
         }
 


### PR DESCRIPTION
Adds a map of implementation notes, keyed by the specification section reference (3.1.1-A, for instance), to the configuration YAML file. Each implementation within the file can detail in plain text their support for certain features or explanations for why a certain test might fail to complete.