### PR TITLE
Report folder config

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/App.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/App.java
@@ -20,6 +20,7 @@ package org.fcrepo.spec.testsuite;
 import static org.fcrepo.spec.testsuite.TestParameters.AUTHENTICATOR_CLASS_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.BROKER_URL_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.CONFIG_FILE_PARAM;
+import static org.fcrepo.spec.testsuite.TestParameters.OUTPUT_DIRECTORY_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.CONSTRAINT_ERROR_GENERATOR_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.IMPLEMENTATION_NAME_PARAM;
 import static org.fcrepo.spec.testsuite.TestParameters.IMPLEMENTATION_VERSION_PARAM;
@@ -45,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -84,6 +86,7 @@ public class App {
     private static Map<String, Boolean> configArgs = new HashMap<>();
 
     private static Map<String, String> implementationNotes = Collections.emptyMap();
+    private static String outputDirectory;
 
     /**
      * Get implementation specific notes, per specifications section reference.
@@ -91,6 +94,14 @@ public class App {
      */
     public static Map<String, String> getImplementationNotes() {
         return App.implementationNotes;
+    }
+
+    /**
+     * Get the high level output directory.
+     * @return String path to output directory
+     */
+    public static String getOutputDirectory() {
+        return App.outputDirectory;
     }
 
     static {
@@ -111,6 +122,7 @@ public class App {
         configArgs.put(CONSTRAINT_ERROR_GENERATOR_PARAM, false);
         configArgs.put(IMPLEMENTATION_NAME_PARAM, false);
         configArgs.put(IMPLEMENTATION_VERSION_PARAM, false);
+        configArgs.put(OUTPUT_DIRECTORY_PARAM, false);
     }
 
     /**
@@ -156,6 +168,8 @@ public class App {
                                      "Requirement levels. One or more of the following, " +
                                      "separated by ',': [ALL|MUST|SHOULD|MAY]"));
         options.addOption(new Option("c", CONFIG_FILE_PARAM, true, "Configuration file of test parameters."));
+        options.addOption(new Option("o", OUTPUT_DIRECTORY_PARAM, true,
+                "Output directory for reports and TestNG output."));
         options.addOption(new Option("n", SITE_NAME_PARAM, true,
                                      "Site name from configuration file (defaults to \"default\")"));
         options.addOption(new Option("k", BROKER_URL_PARAM, true, "The URL of the JMS broker."));
@@ -227,6 +241,12 @@ public class App {
                        "{ implementation version: please use --" + IMPLEMENTATION_VERSION_PARAM + " to specify}");
         }
 
+        if (isNullOrEmpty(params.get(OUTPUT_DIRECTORY_PARAM))) {
+            params.put(OUTPUT_DIRECTORY_PARAM,
+                       ".");
+        }
+        App.outputDirectory = params.get(OUTPUT_DIRECTORY_PARAM);
+
         TestParameters.initialize(params);
         final TestParameters tp = TestParameters.get();
         if (isNullOrEmpty(tp.getQueueName()) &&
@@ -277,6 +297,8 @@ public class App {
 
         final TestNG testng = new TestNG();
         testng.setCommandLineSuite(xmlSuite);
+        final String testngOutput = Paths.get(App.outputDirectory, "test-output").toString();
+        testng.setOutputDirectory(testngOutput);
 
         // Set requirement-level groups to be run
         if (!params.get(REQUIREMENTS_PARAM).isEmpty()) {

--- a/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestParameters.java
@@ -56,6 +56,8 @@ public class TestParameters {
 
     public final static String CONFIG_FILE_PARAM = "config-file";
 
+    public final static String OUTPUT_DIRECTORY_PARAM = "output-directory";
+
     public final static String CONSTRAINT_ERROR_GENERATOR_PARAM = "constraint-error-generator";
 
     public final static String AUTHENTICATOR_CLASS_PARAM = "auth-class";

--- a/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/TestSuiteGlobals.java
@@ -41,7 +41,7 @@ import org.testng.internal.Utils;
  */
 public abstract class TestSuiteGlobals {
     public static final String cssReport = "reportStyle.css";
-    public static final String outputDirectory = "report";
+    public static final String reportOutputDirectory = "report";
     public static final String outputName = "testsuite";
     public static final String earlReportSyntax = "TURTLE";
     public static final String ldptNamespace = "http://fedora.info/2017/06/30/spec/#";
@@ -85,14 +85,14 @@ public abstract class TestSuiteGlobals {
 
     private static void initialize() {
         //create output directory if does not exist
-        final File dir = new File(TestSuiteGlobals.outputDirectory);
+        final File dir = new File(TestSuiteGlobals.reportOutputDirectory);
         if (!dir.exists()) {
             dir.mkdirs();
         }
 
         //remove existing log if exists
         final File f = new File(
-            TestSuiteGlobals.outputDirectory + "/" + TestSuiteGlobals.outputName + "-execution.log");
+            TestSuiteGlobals.reportOutputDirectory + "/" + TestSuiteGlobals.outputName + "-execution.log");
         if (f.exists()) {
             f.delete();
         }
@@ -159,7 +159,7 @@ public abstract class TestSuiteGlobals {
      */
     public static PrintStream logFile() {
         try {
-            final FileOutputStream fos = new FileOutputStream(new File(TestSuiteGlobals.outputDirectory + "/" +
+            final FileOutputStream fos = new FileOutputStream(new File(TestSuiteGlobals.reportOutputDirectory + "/" +
                                                                        TestSuiteGlobals.outputName + "-execution.log"),
                                                               true);
             return new PrintStream(fos);

--- a/src/main/java/org/fcrepo/spec/testsuite/report/EarlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/EarlReporter.java
@@ -19,6 +19,7 @@ package org.fcrepo.spec.testsuite.report;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Paths;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import java.util.Map;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
+import org.fcrepo.spec.testsuite.App;
 import org.fcrepo.spec.testsuite.TestSuiteGlobals;
 import org.testng.IReporter;
 import org.testng.IResultMap;
@@ -49,7 +51,9 @@ public class EarlReporter extends EarlCoreReporter implements IReporter {
     public void generateReport(final List<XmlSuite> xmlSuites, final List<ISuite> suites,
                                final String outputDirectory) {
         try {
-            createWriter(TestSuiteGlobals.outputDirectory);
+            final String myOutputDirectory = Paths.get(App.getOutputDirectory(),
+                    TestSuiteGlobals.reportOutputDirectory).toString();
+            createWriter(myOutputDirectory);
         } catch (IOException e) {
             e.printStackTrace(System.err);
             System.exit(1);

--- a/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/report/HtmlReporter.java
@@ -26,6 +26,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -201,7 +202,9 @@ public class HtmlReporter implements IReporter {
     }
 
     private void createWriter(final String output) {
-        final File dir = new File(TestSuiteGlobals.outputDirectory);
+        final String myOutputDirectory = Paths.get(App.getOutputDirectory(), TestSuiteGlobals.reportOutputDirectory)
+                .toString();
+        final File dir = new File(myOutputDirectory);
         dir.mkdirs();
 
         final String fileName = TestSuiteGlobals.outputName + "-execution-report.html";


### PR DESCRIPTION
This PR adds a -o command line option and a "output-directory" config file option. This is set up to be the base directory for the report folder and the TestNG "test-output" folder. Rationale for this is to facilitate the publication of test results for various platforms. Default test suite behavior is unchanged.