### PR TITLE
Direct container skip

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -52,6 +52,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.message.BasicHeaderValueParser;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.CoreMatchers;
@@ -506,6 +508,37 @@ public class AbstractTest {
         public void describeTo(final Description description) {
             final String msg = expectMatch ? "To contain triple: " : "Not to contain triple: ";
             description.appendText(msg).appendText(triple.toString());
+        }
+    }
+
+    protected class PredicateMatcher<T> extends BaseMatcher<T> {
+
+        private final Resource mysubject;
+        private final Property mypredicate;
+        private final boolean expectMatch;
+
+        public PredicateMatcher(final Resource subject, final Property predicate) {
+            this(subject, predicate, true);
+        }
+
+        public PredicateMatcher(final Resource subject, final Property predicate, final boolean expect) {
+            mysubject = subject;
+            mypredicate = predicate;
+            expectMatch = expect;
+        }
+
+        @Override
+        public boolean matches(final Object item) {
+            final Model model = ModelFactory.createDefaultModel();
+            model.read(new StringReader(item.toString()), "", "TURTLE");
+
+            return model.contains(mysubject, mypredicate) == expectMatch;
+        }
+
+        @Override
+        public void describeTo(final Description description) {
+            final String msg = expectMatch ? "To contain predicate: " : "Not to contain predicate: ";
+            description.appendText(msg).appendText(mypredicate.toString());
         }
     }
 

--- a/src/main/java/org/fcrepo/spec/testsuite/authz/WebACDefaultACLs.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/authz/WebACDefaultACLs.java
@@ -50,16 +50,17 @@ public class WebACDefaultACLs extends AbstractAuthzTest {
         final Headers headers = new Headers(new Header("Content-Type", "text/turtle"));
 
         //create a resource
-        final String grandParentUri = createResource(rootUri, info.getId());
+        final String grandParentUri = createResource(uri, info.getId());
         //create an acl with acl:default with write privileges
         createAclForResource(grandParentUri, "user-read-write.ttl", this.permissionlessUserWebId);
+
         //create a child  and child acl with read privileges and no acl:default
-        final Response childPost = doPost(grandParentUri, headers, simpleRDFBody);
+        final Response childPost = createBasicContainer(grandParentUri, "child", simpleRDFBody);
         final String childUri = getLocation(childPost);
         createAclForResource(childUri, "user-read-only-no-default.ttl", this.permissionlessUserWebId);
 
         //create a grandchild  with no acl.
-        final Response grandChildPost = doPost(childUri, headers, simpleRDFBody);
+        final Response grandChildPost = createBasicContainer(childUri, "grandchild", simpleRDFBody);
         final String grandChildUri = getLocation(grandChildPost);
 
         // verify that the user can read and write to the grandparent

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
@@ -60,6 +60,7 @@ public class Container extends AbstractTest {
     private static final String CONTAINER_SPEC_LINK = SPEC_BASE_URL + "#ldpc";
     private static final String DIRECT_CONTAINER_SPEC_LINK = SPEC_BASE_URL + "#ldpdc";
     private static final String INDIRECT_CONTAINER_SPEC_LINK = SPEC_BASE_URL + "#ldpic";
+    private static final String CONTAINER_CONSTRAINTS_SPEC_LINK = SPEC_BASE_URL + "#constraints-document";
 
     /**
      * 3.1.1-A-1
@@ -189,6 +190,7 @@ public class Container extends AbstractTest {
                                         "LDP Containers must distinguish [membership] triples.",
                                         CONTAINER_SPEC_LINK,
                                         ps);
+        skipIfDirectContainersNotSupported();
         final Response base = createBasicContainer(uri, info);
 
         final Response container = createBasicContainer(getLocation(base), "container");
@@ -202,7 +204,6 @@ public class Container extends AbstractTest {
         final Response direct = createDirectContainerUnverified(getLocation(base), directBody);
         if (direct.getStatusCode() == 409) {
             verifyConstraintHeader(direct);
-
         } else if (direct.statusCode() == 201) {
             final Response directMember = createBasicContainer(getLocation(direct), "member");
 
@@ -1351,5 +1352,54 @@ public class Container extends AbstractTest {
 
     }
 
+    /**
+     * 3.1.5-1
+     */
+    @Test(groups = {"MUST"})
+    public void ldpDirectContainerSupportOrConstraintsDocument() {
+        setupTest("3.1.5-1",
+                  "When implementation choices result in failure to complete a client request, " +
+                  "response MUST include a Link header with a link relation of " +
+                  "http://www.w3.org/ns/ldp#constrainedBy, and a target URI identifying a document. " +
+                  "(direct container support)",
+                  CONTAINER_CONSTRAINTS_SPEC_LINK,
+                  ps);
+        try {
+            skipIfDirectContainersNotSupported();
+        } catch (SkipException e) {
+            final Response direct = createDirectContainerUnverified(uri, DIRECT_CONTAINER_BODY);
+            if (clientErrorRange().matches(direct.getStatusCode())) {
+                verifyConstraintHeader(direct);
+            }
+            if (direct.getStatusCode() != 409) {
+                Assert.fail("Unexpected response code: " + direct.getStatusCode());
+            }
+        }
+    }
+
+    /**
+     * 3.1.5-2
+     */
+    @Test(groups = {"MUST"})
+    public void ldpIndirectContainerSupportOrConstraintsDocument() {
+        setupTest("3.1.5-2",
+                  "When implementation choices result in failure to complete a client request, " +
+                  "response MUST include a Link header with a link relation of " +
+                  "http://www.w3.org/ns/ldp#constrainedBy, and a target URI identifying a document. " +
+                  "(indirect container support)",
+                  CONTAINER_CONSTRAINTS_SPEC_LINK,
+                  ps);
+        try {
+            skipIfIndirectContainersNotSupported();
+        } catch (SkipException e) {
+            final Response indirect = createIndirectContainerUnverified(uri, INDIRECT_CONTAINER_BODY);
+            if (clientErrorRange().matches(indirect.getStatusCode())) {
+                verifyConstraintHeader(indirect);
+            }
+            if (indirect.getStatusCode() != 409) {
+                Assert.fail("Unexpected response code: " + indirect.getStatusCode());
+            }
+        }
+    }
 
 }

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
@@ -811,14 +811,17 @@ public class Container extends AbstractTest {
         //throw skip exception if indirect containers not supported
         skipIfIndirectContainersNotSupported();
 
-        final String membershipResource = getLocation(doPost(uri));
+        final String memberICR = "http://example.org/notldp/NotMemberSubject";
 
         final String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> .\n"
-                            + "<> ldp:membershipResource <" + membershipResource + "> ;";
+                            + "<> ldp:membershipResource <#it> ;\n"
+                            + "<" + LDP_INSERTED_CONTENT_RELATION_PREDICATE + "> <" + memberICR + "> ;\n"
+                            + "ldp:hasMemberRelation <ldp:member> .";
         final Response container = createIndirectContainer(uri, body);
         final String containerResource = getLocation(container);
         confirmPresenceOrAbsenceOfTripleInResponse(doGet(containerResource), containerResource,
-                                                   LDP_MEMBERSHIP_RESOURCE_PREDICATE, membershipResource, true);
+                                                   LDP_MEMBERSHIP_RESOURCE_PREDICATE,
+                                                   containerResource + "#it", true);
     }
 
     /**
@@ -952,15 +955,19 @@ public class Container extends AbstractTest {
     public void ldpIndirectContainerMustAllowHasMemberRelationPredicateToBeSetOnCreate() {
         setupTest("3.1.3-F",
                   "Implementations must allow the membership predicate to be set on indirect containers " +
-                  "via either the ldp:hasMemberRelation or ldp:isMemberOfRelation property " +
+                  "via either the ldp:hasMemberRelation property " +
                   "of the content RDF on container creation.",
                   INDIRECT_CONTAINER_SPEC_LINK,
                   ps);
         //throw skip exception if indirect containers not supported
         skipIfIndirectContainersNotSupported();
 
+        final String memberICR = "http://example.org/notldp/NotMemberSubject";
+
         final String hasMemberPredicate = "http://example.org/ldp/member";
-        final String body = "<> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + hasMemberPredicate + "> ;";
+        final String body = "<> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + hasMemberPredicate + "> ;\n"
+                + "<" + LDP_INSERTED_CONTENT_RELATION_PREDICATE + "> <" + memberICR + "> ;\n"
+                + "<" + LDP_MEMBERSHIP_RESOURCE_PREDICATE + ">" + " <#it> .";
         final Response container = createIndirectContainer(uri, body);
         final String containerResource = getLocation(container);
         confirmPresenceOrAbsenceOfTripleInResponse(doGet(containerResource), containerResource,
@@ -981,8 +988,12 @@ public class Container extends AbstractTest {
         //throw skip exception if indirect containers not supported
         skipIfIndirectContainersNotSupported();
 
+        final String memberICR = "http://example.org/notldp/NotMemberSubject";
+
         final String isMemberPredicate = "http://example.org/ldp/isMemberOf";
-        final String body = "<> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberPredicate + "> ;";
+        final String body = "<> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberPredicate + "> ;\n"
+                            + "<" + LDP_INSERTED_CONTENT_RELATION_PREDICATE + "> <" + memberICR + "> ;\n"
+                            + "<" + LDP_MEMBERSHIP_RESOURCE_PREDICATE + ">" + " <#it> .";
         final Response container = createIndirectContainer(uri, body);
         final String containerResource = getLocation(container);
         confirmPresenceOrAbsenceOfTripleInResponse(doGet(containerResource), containerResource,
@@ -1224,8 +1235,14 @@ public class Container extends AbstractTest {
         //throw skip exception if indirect containers not supported
         skipIfIndirectContainersNotSupported();
 
+        final String membershipResource = getLocation(doPost(uri));
+        final String hasMemberPredicate = "http://example.org/ldp/member";
         final String memberSubject = "http://example.org/ldp/MemberSubject";
-        final String body = "<> <" + LDP_INSERTED_CONTENT_RELATION_PREDICATE + "> <" + memberSubject + "> ;";
+
+        final String body = "<> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + hasMemberPredicate + "> ;\n"
+                + "<" + LDP_INSERTED_CONTENT_RELATION_PREDICATE + "> <" + memberSubject + "> ;\n"
+                + "<" + LDP_MEMBERSHIP_RESOURCE_PREDICATE + ">" + " <" + membershipResource + "> .";
+
         final Response container = createIndirectContainer(uri, body);
         final String containerResource = getLocation(container);
         confirmPresenceOrAbsenceOfTripleInResponse(doGet(containerResource), containerResource,

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/Container.java
@@ -380,7 +380,8 @@ public class Container extends AbstractTest {
         final String membershipResource = getLocation(doPost(uri));
 
         final String body = "@prefix ldp: <http://www.w3.org/ns/ldp#> .\n"
-                            + "<> ldp:membershipResource <" + membershipResource + "> ;";
+                            + "<> ldp:membershipResource <" + membershipResource + "> ;\n"
+                            + "ldp:hasMemberRelation <ldp:member> .";
         final Response directContainer = createDirectContainer(uri, body);
         final String directContainerResource = getLocation(directContainer);
         confirmPresenceOrAbsenceOfTripleInResponse(doGet(directContainerResource), directContainerResource,
@@ -535,8 +536,11 @@ public class Container extends AbstractTest {
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
 
+        final String membershipResource = getLocation(doPost(uri));
+
         final String hasMemberPredicate = "http://example.org/ldp/member";
-        final String body = "<> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + hasMemberPredicate + "> ;";
+        final String body = "<> <" + LDP_HAS_MEMBER_RELATION_PREDICATE + "> <" + hasMemberPredicate + "> ;\n"
+                + "<" + LDP_MEMBERSHIP_RESOURCE_PREDICATE + ">" + " <" + membershipResource + "> .";
         final Response directContainer = createDirectContainer(uri, body);
         final String directContainerResource = getLocation(directContainer);
         confirmPresenceOrAbsenceOfTripleInResponse(doGet(directContainerResource), directContainerResource,
@@ -559,8 +563,11 @@ public class Container extends AbstractTest {
         //throw skip exception if direct containers not supported
         skipIfDirectContainersNotSupported();
 
+        final String membershipResource = getLocation(doPost(uri));
+
         final String isMemberPredicate = "http://example.org/ldp/isMemberOf";
-        final String body = "<> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberPredicate + "> ;";
+        final String body = "<> <" + LDP_IS_MEMBER_OF_RELATION_PREDICATE + "> <" + isMemberPredicate + "> ;\n"
+                + "<" + LDP_MEMBERSHIP_RESOURCE_PREDICATE + ">" + " <" + membershipResource + "> .";
         final Response directContainer = createDirectContainer(uri, body);
         final String directContainerResource = getLocation(directContainer);
         confirmPresenceOrAbsenceOfTripleInResponse(doGet(directContainerResource), directContainerResource,

--- a/src/main/java/org/fcrepo/spec/testsuite/event/NotificationTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/event/NotificationTest.java
@@ -224,9 +224,7 @@ public class NotificationTest extends AbstractEventTest {
         // Start listening to the broker.
         connection.start();
 
-        containerTypes.stream().forEach(type -> {
-            doContainerTypeTest(uri, type, listener);
-        });
+        doContainerTypeTest(uri, ldpBasicContainer, listener);
 
         consumer.close();
 


### PR DESCRIPTION
This code primarily separates direct and indirect container support from other related requirements, including the ldp:constrainedBy header requirement. It ensured that some additional tests are skipped when direct or indirect containers are not supported (Prefer membership). It creates a separate set of tests for the ldp:constrainedBy Link header.

Note: This will require rebase after/if other PRs are accepted.