### PR TITLE
Ensures that before and after comparisons are not including server ma…

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/AbstractTest.java
@@ -17,29 +17,6 @@
  */
 package org.fcrepo.spec.testsuite;
 
-import static io.restassured.config.RedirectConfig.redirectConfig;
-import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
-import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_BODY;
-import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_LINK_HEADER;
-import static org.fcrepo.spec.testsuite.Constants.SLUG;
-import static org.fcrepo.spec.testsuite.TestSuiteGlobals.registerTestResource;
-import static org.fcrepo.spec.testsuite.authn.AuthUtil.auth;
-import static org.testng.AssertJUnit.fail;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.io.PrintStream;
-import java.io.StringReader;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-import javax.ws.rs.core.Link;
-
 import io.restassured.RestAssured;
 import io.restassured.config.EncoderConfig;
 import io.restassured.config.LogConfig;
@@ -63,6 +40,29 @@ import org.hamcrest.Matchers;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+
+import javax.ws.rs.core.Link;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static io.restassured.config.RedirectConfig.redirectConfig;
+import static org.fcrepo.spec.testsuite.Constants.APPLICATION_SPARQL_UPDATE;
+import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_BODY;
+import static org.fcrepo.spec.testsuite.Constants.BASIC_CONTAINER_LINK_HEADER;
+import static org.fcrepo.spec.testsuite.Constants.SLUG;
+import static org.fcrepo.spec.testsuite.TestSuiteGlobals.registerTestResource;
+import static org.fcrepo.spec.testsuite.authn.AuthUtil.auth;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * A crud base class for common crud functions.
@@ -376,8 +376,8 @@ public class AbstractTest {
         return auth(RestAssured.given(), webId).urlEncodingEnabled(false);
     }
 
-    protected Response doGet(final String uri, final Header header) {
-        final Response response = doGetUnverified(uri, header);
+    protected Response doGet(final String uri, final Header... headers) {
+        final Response response = doGetUnverified(uri, headers);
 
         response.then().statusCode(200);
 
@@ -396,8 +396,12 @@ public class AbstractTest {
         return doGet(uri, true);
     }
 
-    protected Response doGetUnverified(final String uri, final Header header) {
-        return createRequest().header(header).when().get(uri);
+    protected Response doGetUnverified(final String uri, final Header... headers) {
+        final RequestSpecification request = createRequest();
+        for (Header header : headers) {
+            request.header(header);
+        }
+        return request.when().get(uri);
     }
 
     protected Response doGetUnverified(final String uri) {

--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdpcvHttpPost.java
@@ -38,6 +38,9 @@ import org.testng.annotations.Test;
  */
 public class LdpcvHttpPost extends AbstractVersioningTest {
 
+    private static final String PREFER_MINIMAL_CONTAINER_HEADER = "return=representation; " +
+            "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"";
+
     /**
      * 4.3 may disallow post
      */
@@ -83,8 +86,9 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
         // create the versioned resource
         final Response createResponse = createVersionedResource(uri, info);
 
-        // get the new resource, which should have all the proper memento headers
-        final Response origResponse = doGet(getLocation(createResponse), acceptNTriplesHeader);
+        // get the new resource, which should have all the proper memento headers and return only minimal container
+        final Header preferHeader = new Header("Prefer", PREFER_MINIMAL_CONTAINER_HEADER);
+        final Response origResponse = doGet(getLocation(createResponse), acceptNTriplesHeader, preferHeader);
         final URI timeMapURI = getTimeMapUri(origResponse);
 
         // create a version on the resource
@@ -94,7 +98,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
         confirmPresenceOfVersionLocationHeader(timeMapResponse);
 
         // get the new memento
-        final Response versionResponse = doGet(getLocation(timeMapResponse), acceptNTriplesHeader);
+        final Response versionResponse = doGet(getLocation(timeMapResponse), acceptNTriplesHeader, preferHeader);
 
         // is the memento exactly the same as the original?
         confirmResponseBodyNTriplesAreEqual(origResponse, versionResponse);
@@ -156,8 +160,9 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
         // create the versioned resource
         final Response createResponse = createVersionedResource(uri, info);
 
-        // get the new resource, which should have all the proper memento headers
-        final Response origResponse = doGet(getLocation(createResponse), acceptNTriplesHeader);
+        // get the new resource, which should have all the proper memento headers and return only minimal container
+        final Header preferHeader = new Header("Prefer", PREFER_MINIMAL_CONTAINER_HEADER);
+        final Response origResponse = doGet(getLocation(createResponse), acceptNTriplesHeader, preferHeader);
         final URI timeMapURI = getTimeMapUri(origResponse);
 
         // create a memento for the current time
@@ -166,7 +171,7 @@ public class LdpcvHttpPost extends AbstractVersioningTest {
         // should have location header information of new memento
         confirmPresenceOfVersionLocationHeader(timeMapResponse);
 
-        final Response versionResponse = doGet(getLocation(timeMapResponse), acceptNTriplesHeader);
+        final Response versionResponse = doGet(getLocation(timeMapResponse), acceptNTriplesHeader, preferHeader);
 
         // does the version look like the original still?
         confirmResponseBodyNTriplesAreEqual(origResponse, versionResponse);


### PR DESCRIPTION
…naged timestamps that change when new mementos are created when 4.3.3.1-A and 4.3.3.1-C. This filtering is necessary because Fedora 6 will update the last modified date of resources when a new version is stamped. 

Resolves:
   * https://jira.lyrasis.org/browse/FCREPO-3596
   * https://jira.lyrasis.org/browse/FCREPO-3595

