### PR TITLE
Fixes 3.6.1-A: PUT with body

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
@@ -112,8 +112,10 @@ public class HttpPut extends AbstractTest {
                                         SPEC_BASE_URL + "#http-put-ldprs", ps);
         final Response resource = createBasicContainer(uri, info);
         final String locationHeader = getLocation(resource);
-
-        final Response getResponse = doGet(locationHeader);
+        final Header preferHeader = new Header("Prefer",
+                "return=representation; include=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\"; " +
+                        "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"");
+        final Response getResponse = doGet(locationHeader, preferHeader);
         final String body2 = getResponse.asString();
         final String etag = getETag(getResponse);
 

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/HttpPut.java
@@ -114,7 +114,7 @@ public class HttpPut extends AbstractTest {
         final String locationHeader = getLocation(resource);
         final Header preferHeader = new Header("Prefer",
                 "return=representation; include=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\"; " +
-                        "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"");
+                        "omit=\"http://fedora.info/definitions/fcrepo#ServerManaged\"");
         final Response getResponse = doGet(locationHeader, preferHeader);
         final String body2 = getResponse.asString();
         final String etag = getETag(getResponse);


### PR DESCRIPTION
 Fixes 3.6.1-A: Fedora 5 ignores SMTs by default.  Fedora 6 does not. Therefore before PUT we are pulling back only the user triples.

Resolves: https://jira.lyrasis.org/browse/FCREPO-3592

Test by running the test suite and verifying that 3.6.1-A now passes.