### PR TITLE
Fixes 3.10.2-D: the problem is Fedora 6 no longer accepts SMTs by def…

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/crud/StateToken.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/StateToken.java
@@ -193,7 +193,10 @@ public class StateToken extends AbstractTest {
                                         SPEC_BASE_URL + "#x-if-state-token", ps);
         final Response createResponse = createBasicContainer(uri, info.getId());
         final String resourceUri = getLocation(createResponse);
-        final Response getResponse = doGet(resourceUri);
+        final Header preferHeader = new Header("Prefer", "return=representation; " +
+                "include=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\"; " +
+                "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"");
+        final Response getResponse = doGet(resourceUri, preferHeader);
 
         //throw skip exception if state token not supported
         skipIfStateTokenNotSupported(getResponse);

--- a/src/main/java/org/fcrepo/spec/testsuite/crud/StateToken.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/crud/StateToken.java
@@ -195,7 +195,7 @@ public class StateToken extends AbstractTest {
         final String resourceUri = getLocation(createResponse);
         final Header preferHeader = new Header("Prefer", "return=representation; " +
                 "include=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\"; " +
-                "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"");
+                "omit=\"http://fedora.info/definitions/fcrepo#ServerManaged\"");
         final Response getResponse = doGet(resourceUri, preferHeader);
 
         //throw skip exception if state token not supported


### PR DESCRIPTION
…ault.

Resolves: https://jira.lyrasis.org/browse/FCREPO-3591

Test by running the test suite and verify 3.10.2-D passes.