### PR TITLE
Fixes 4.1.2-B: Must support PUT for updating existing LDPRvs

### DIFF
--- a/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpPut.java
+++ b/src/main/java/org/fcrepo/spec/testsuite/versioning/LdprvHttpPut.java
@@ -101,7 +101,10 @@ public class LdprvHttpPut extends AbstractVersioningTest {
         final String resourceUri = getLocation(response);
 
         final Header acceptTurtleHeader = new Header("Accept", "text/turtle");
-        final Response getResponse = doGet(resourceUri, acceptTurtleHeader);
+        final Header preferHeader = new Header("Prefer", "return=representation; " +
+                "include=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\"; " +
+                "omit=\"http://fedora.info/definitions/fcrepo#ServerManaged\"");
+        final Response getResponse = doGet(resourceUri, preferHeader);
         //verify that "Allow: PUT" header is present
         confirmPresenceOfHeaderValueInMultiValueHeader("Allow", "PUT", getResponse);
 


### PR DESCRIPTION
Using these instructions, run the api test suite against fcrepo/fcrepo `main` HEAD.
https://wiki.lyrasis.org/display/FF/Test+Guide+-+Fedora+API+Specification+Test+Suite

Verify that test now passes.
Resolves: https://jira.lyrasis.org/browse/FCREPO-3593